### PR TITLE
Updates to build.md and customize.md

### DIFF
--- a/docs/EN/operate/build.md
+++ b/docs/EN/operate/build.md
@@ -75,8 +75,7 @@ The **TrioBuildSelectScript** offers the choice to:
 1. [Build Trio](#build-trio)
 2. [Build Related Apps](#build-related-apps)
 3. [Run Maintenance Utilities](#run-maintenance-utilities)
-4. [Customize Trio](#customize-trio)
-5. Exit Script
+4. Exit Script
 
 To execute the **TrioBuildSelectScript**, open a terminal on your Mac and copy and paste the command below into the terminal. Then, read and follow the directions. 
 
@@ -122,15 +121,6 @@ The following options are offered:
 
 For more information, refer to [Loop and Learn: Maintenance Utitilites](https://www.loopandlearn.org/build-select/#utilities-disk) documentation.
 
-#### Customize Trio
-
-When you select **Customize Trio**, you will be provided with a choice of customization options:
-
-1. [Change Default to Upload Dexcom Readings](https://www.loopandlearn.org/custom-code/#dexcom-remote-enable)
-2. [Disable Authentication Requirement](https://www.loopandlearn.org/custom-code/#disable-authentication)
-3. Return to Menu
-
-The customizations are a subset of those provided for the Loop app. Some of the code in Trio is shared with Loop so these customizations are common. The two that are used by Trio have links to the Loop and Learn documentation in the list above.
 
 #### Build Errors
 

--- a/docs/EN/operate/build.md
+++ b/docs/EN/operate/build.md
@@ -26,6 +26,7 @@ The Trio repository contains instructions for building the Trio app using a brow
       * `org.nightscout.TEAMID.trio`
       * `org.nightscout.TEAMID.trio.watchkitapp`
       * `org.nightscout.TEAMID.trio.watchkitapp.watchkitextension`
+      * `org.nightscout.TEAMID.trio.LiveActivity`
   * The `org.nightscout.TEAMID.trio` identifier, in addition to `App Group`, must also have the `HealthKit` and `NFC Tag Reading` boxes checked (which should be automatic)
   * In `App Store Connect`, the `Bundle ID` for Trio will be: `org.nightscout.TEAMID.trio`
 

--- a/docs/EN/operate/build.md
+++ b/docs/EN/operate/build.md
@@ -175,20 +175,26 @@ If you prefer the command line interface, skip ahead to [Update Trio with CLI](#
 
 ### Update Trio with Source Control
 
-::: Released code is found in the `main` branch. These figures show the older name of `master` rather than `main`. 
+::: Released code is found in the `main` branch. These figures show the older name of `master` rather than `main`.  They also show an older version of Xcode. The menus have changed, so follow the words below, not the graphics.
+:::
 
 Open Xcode. If your Trio (FreeAPS) workspace is not already open, you can usually find it in the recent projects, as shown in the graphic below. You can also pull down the Xcode menu for `File`, select `Open Recent`, and find your workspace.
 
 <img src="https://github.com/nightscout/trio-docs/assets/31315442/024fc3f9-6bca-475f-b270-17d43da4a4d8" width="600px"/>
 
-Refer to the graphic below:
-1. Click Source Control
-2. Choose `Fetch changes`
+The graphic below needs to be updated:
+1. There are 2 methods to open `Source Control`
+    * Hold down the command key and hit 2 (cmd-2)
+    * Use the menus to select `View`, `Navigate`, `Source Control`
+2. This modifies the Xcode display with two tabs:
+    * There is a `Changes` tab and a `Repositories` tab
+    * It might say `No changes`, but fetch changes to make sure
+2. Tap on the `Integrate` menu and select `Fetch changes`
 
 <img src="https://github.com/nightscout/trio-docs/assets/31315442/0356efea-351c-4d31-89e6-d04ffee5bab8" width="600px"/>
 
-Refer to the graphic below:
-1. Click Source Control again
+The graphic below needs to be updated:
+1. Click `Integrate` again
 2. Select `Pull…`
 
 <img src="https://github.com/nightscout/trio-docs/assets/31315442/2fa2f70b-86a3-4f62-9a69-80caf0137fca" width="600px"/>

--- a/docs/EN/operate/build.md
+++ b/docs/EN/operate/build.md
@@ -117,9 +117,10 @@ When you select **Run Maintenance Utilities**, you will be provided with a choic
 The following options are offered:
 
 1. Delete Old Downloads
-1. Clean Derived Data
-1. Xcode Cleanup (The Big One)
-1. Return to Menu
+2. Clean Derived Data
+3. Xcode Cleanup (The Big One)
+4. Clean Profiles
+5. Return to Menu
 
 For more information, refer to [Loop and Learn: Maintenance Utitilites](https://www.loopandlearn.org/build-select/#utilities-disk) documentation.
 
@@ -191,7 +192,7 @@ The graphic below needs to be updated:
 2. This modifies the Xcode display with two tabs:
     * There is a `Changes` tab and a `Repositories` tab
     * It might say `No changes`, but fetch changes to make sure
-2. Tap on the `Integrate` menu and select `Fetch changes`
+3. Tap on the `Integrate` menu and select `Fetch changes`
 
 <img src="https://github.com/nightscout/trio-docs/assets/31315442/0356efea-351c-4d31-89e6-d04ffee5bab8" width="600px"/>
 

--- a/docs/EN/operate/build.md
+++ b/docs/EN/operate/build.md
@@ -14,21 +14,23 @@ The Trio repository contains instructions for building the Trio app using a brow
 
 :::{tip} If using the LoopDocs instructions you need the important information below to build Trio intead of Loop
 :::
-  * Fork from: [https://github.com/nightscout/Trio](https://github.com/nightscout/Trio)
-  * `Identifier Names` will be: `FreeAPS`, `FreeAPSWatch`, `FreeAPSWatch WatchKit Extension`, `LiveActivityExtension`
-  * `Identifiers` will be:
-      * `org.nightscout.TEAMID.trio`
-      * `org.nightscout.TEAMID.trio.watchkitapp`
-      * `org.nightscout.TEAMID.trio.watchkitapp.watchkitextension`
-      * `org.nightscout.TEAMID.trio.LiveActivity`
-  * Make sure the box next to `App Group` is checked, and click `Configure` to select the same app group as Loop: `group.com.TEAMID.loopkit.LoopGroup`
-  * You must add this `App Group` to each of the following identifiers:
-      * `org.nightscout.TEAMID.trio`
-      * `org.nightscout.TEAMID.trio.watchkitapp`
-      * `org.nightscout.TEAMID.trio.watchkitapp.watchkitextension`
-      * `org.nightscout.TEAMID.trio.LiveActivity`
-  * The `org.nightscout.TEAMID.trio` identifier, in addition to `App Group`, must also have the `HealthKit` and `NFC Tag Reading` boxes checked (which should be automatic)
-  * In `App Store Connect`, the `Bundle ID` for Trio will be: `org.nightscout.TEAMID.trio`
+
+* Fork from: [https://github.com/nightscout/Trio](https://github.com/nightscout/Trio)
+* `Identifier Names` will be: `FreeAPS`, `FreeAPSWatch`, `FreeAPSWatch WatchKit Extension`, `LiveActivityExtension`
+    * These names are the same as that used by iAPS, they are distinguised by the Identifier itself, which include the new BundleID for your Trio app
+    * If you build with Xcode before, they will start with XC and use the Identifier string rather than the Name
+* `Identifiers` will be:
+    * `org.nightscout.TEAMID.trio`
+    * `org.nightscout.TEAMID.trio.watchkitapp`
+    * `org.nightscout.TEAMID.trio.watchkitapp.watchkitextension`
+    * `org.nightscout.TEAMID.trio.LiveActivity`
+* Only the first 3 of these identifiers need to have the `App Group` added
+* For the list below, make sure the box next to `App Group` is checked, and click `Configure` to select the same app group as Loop: `group.com.TEAMID.loopkit.LoopGroup`
+* You must add this `App Group` to each of the following identifiers:
+    * `org.nightscout.TEAMID.trio`
+    * `org.nightscout.TEAMID.trio.watchkitapp`
+    * `org.nightscout.TEAMID.trio.watchkitapp.watchkitextension`
+* In `App Store Connect`, the `Bundle ID` for Trio will be: `org.nightscout.TEAMID.trio`
 
 ### One-Time Update to Display Branch And Commit in Testflight
 

--- a/docs/EN/operate/customize.md
+++ b/docs/EN/operate/customize.md
@@ -11,12 +11,9 @@ Here are a few ways to customize the Trio code to suit your needs better. Please
 
 Depending on your iPhone settings and model, you may have Face ID or Touch ID enabled. Those security features will also be used to authenticate bolus delivery in Trio. You can disable authentication (i.e., not require Face ID, Touch ID, or passcode for bolusing) through the following code customization.
 
-You can find the script for this customization here [Customize Trio](build.md#customize-trio). Trio uses many submodules from the LoopKit username with FreeAPS and oref code as the manager.
-
 **Steps:**
 
-Edit line 20 of the file `LoopKit/LoopKitUI/Extensions/Environment+Authenticate.swift`
-
+Edit line 20 of the file `FreeAPS/Sources/Services/UnlockManager/UnlockManager.swift`
 
 Code before modification: 
 ```swift


### PR DESCRIPTION
* Add LiveActivity to identifier list that needs App Group
* Remove reference to customization script
* Correct the file name required to bypass authentication
* Fixed a missing highlight indicator so page will render properly
* Updated words for Xcode Source Control section to work with Xcode 15 and indicate tabs for Trio vs Submodules (Repositories)