### PR TITLE
add sphinx_copybutton extension

### DIFF
--- a/docs/shared.conf.py
+++ b/docs/shared.conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'myst_parser',
+    'sphinx_copybutton',
     # 'alabaster',
 ]
 

--- a/docs/shared.conf.py
+++ b/docs/shared.conf.py
@@ -388,3 +388,10 @@ epub_exclude_files = ['search.html']
 #            'enable_eval_rst': True,
 #            }, True)
 #    #app.add_transform(AutoStructify)
+
+# Allows preventing copy button from being added to code blocks like so:
+# ```{code-block}
+# :class: no-copybutton
+# the code you want to display goes here
+# ```
+copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==5.3.0
 sphinx_rtd_theme==1.2.0
+sphinx_copybutton
 myst_parser==0.18.1


### PR DESCRIPTION
Adds copy buttons to code blocks, like so:

<img width="815" alt="Screenshot 2024-05-16 at 2 47 00 PM" src="https://github.com/nightscout/trio-docs/assets/82073483/60086a19-366b-4f1a-b824-6dded27c86ba">


You can see it in action [here](https://oidocs-mikeplante1.readthedocs.io/en/sphinx_copybutton/operate/build.html#build-trio-with-script)