### PR TITLE
Allow pdf and epub

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -15,3 +15,7 @@ python:
 sphinx:
   builder: html
   fail_on_warning: false
+
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
Per @pheltzel & @Sjoerd-Bo3 ’s request, I added PDF as an option for the docs. I also added epub since it was in the same guide, but am not familiar with that format so let me know if it’s useful or if I should remove it and only offer pdf. 

I guess I should have used a different name for the branch, but oh well: https://oidocs-mikeplante1.readthedocs.io/en/pdf/

![IMG_4636](https://github.com/nightscout/trio-docs/assets/82073483/df2b2be2-034c-4690-bfb6-e80e3dab4a3e)
