### PR TITLE
Fix `14 day` TDD avg for DynISF to `10 day`

### DIFF
--- a/docs/EN/settings/configuration/concepts/autosens-dynamic.md
+++ b/docs/EN/settings/configuration/concepts/autosens-dynamic.md
@@ -103,7 +103,7 @@ See `Weighted Average of TDD` setting to understand how this variable is calcula
 
 **Example:**
 
-_Bill's TDD has been 55 U over the last 24 hours, and his 14-day average is 48 U. He has set his `Weighted average of TDD` in preferences to 0.7. His current profile basal rate is 1 U/h._
+_Bill's TDD has been 55 U over the last 24 hours, and his 10-day average is 48 U. He has set his `Weighted average of TDD` in preferences to 0.7. His current profile basal rate is 1 U/h._
 
 ```{math}
 Weighted\ average\ of\ TDD\ =\ 0.7 * 55 U + 0.3 * 48 U = 52.9 U

--- a/docs/EN/settings/configuration/preferences/dynamicsettings.md
+++ b/docs/EN/settings/configuration/preferences/dynamicsettings.md
@@ -52,7 +52,7 @@ This ratio is used by "Adjust basal" for its calculations. It allows you to effe
 >Set at **0.65** (default) = 65% of the TDD from the past 24 hours + 35% of the TDD from the past 2 weeks
 >Set at **0.0** = uses 100% of the TDD from the past 2 weeks
 
-**Example:** _Bill has a TDD of 55 U over the last 24 hours. He has had a TDD of 48 U over the last 14 days. His Weighted Average is set at 0.65:_
+**Example:** _Bill has a TDD of 55 U over the last 24 hours. He has had a TDD of 48 U over the last 10 days. His Weighted Average is set at 0.65:_
 ```{math}
 TDD Average = 55 * 0.65 + 48 * 0.35 = 52.55
 ```


### PR DESCRIPTION
Variable were poorly named `tdd24h_14d_Ratio` and `average14` in iAPS but actually used 10-day averages, which led to this confusion.

This commit updates the docs to reflect the actual value used in Trio (10 days).