### PR TITLE
🙈 Configure Git to ignore the `venv/` and `docs/_build/` folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # macOS
 .DS_Store
+
+# Sphinx documentation
+docs/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Sphinx documentation
 docs/_build/
+
+# Python Virtual Environment
+venv/


### PR DESCRIPTION
This PR adds the `venv/` and `docs/_build/` patterns to `.gitignore`.

The **goal** is respectively not to commit files from:
- the Python Virtual Environment (*venv*)
- the local build output folder