### PR TITLE
✏️ Fix typo in the example of Max Daily Safety Multiplier

### DIFF
--- a/docs/EN/settings/configuration/preferences/mainsettings.md
+++ b/docs/EN/settings/configuration/preferences/mainsettings.md
@@ -72,7 +72,7 @@ Limits the maximum temporary basal rate Trio is able to use at _any time_. The d
 >```
 
 >the maximum temporary basal rate that can be set is **3 units per hour**
->```{math} 1.0 \times 3 = 3
+>```{math} 2.0 \times 3 = 6
 >```
 
 ## Current Basal Safety Multiplier 


### PR DESCRIPTION
This PR aims to fix #75 where there is a typo.
In the [**example** of **Max Daily Safety Multiplier**](https://docs.diy-trio.org/en/latest/settings/configuration/preferences/mainsettings.html#max-daily-safety-multiplier
):
the max hourly basal rate is `1.0` whereas it should be `2.0`.