### PR TITLE
✏️ Fix Typo in `Max Daily Safety Multiplier`

### DIFF
--- a/docs/EN/settings/configuration/preferences/mainsettings.md
+++ b/docs/EN/settings/configuration/preferences/mainsettings.md
@@ -71,7 +71,7 @@ Limits the maximum temporary basal rate Trio is able to use at _any time_. The d
 >```{math} Highest\ Hourly\ Basal \times Max\ Daily\ Safety\ Multiplier = Maximum\ Temporary\ Basal\ Rate
 >```
 
->the maximum temporary basal rate that can be set is **3 units per hour**
+>the maximum temporary basal rate that can be set is **6 units per hour**
 >```{math} 2.0 \times 3 = 6
 >```
 


### PR DESCRIPTION
In PR #76, I forgot to fix this occurrence of the `Maximum Temporary Basal` value in the text.
This PR now fixes it.

Source: [Facebook](https://www.facebook.com/groups/diytrio/permalink/1694077144659467/?rdid=BQjZ6WkIPxJeMxBE&share_url=https://www.facebook.com/share/p/PpTxiKnC3B3guorr/)
