### PR TITLE
👷 Add a GitHub workflow to prevent blocked PRs from being merged

### DIFF
--- a/.github/workflows/pr_dependencies_check.yml
+++ b/.github/workflows/pr_dependencies_check.yml
@@ -1,0 +1,23 @@
+name: Prevent Blocked PRs from being Merged
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+    issues:
+      types:
+        - opened
+        - edited
+        - deleted
+        - transferred
+        - closed
+        - reopened
+
+jobs:
+  blocking_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Levi-Lesches/blocking-issues@v2

--- a/.github/workflows/pr_dependencies_check.yml
+++ b/.github/workflows/pr_dependencies_check.yml
@@ -7,14 +7,14 @@ on:
       - edited
       - closed
       - reopened
-    issues:
-      types:
-        - opened
-        - edited
-        - deleted
-        - transferred
-        - closed
-        - reopened
+  issues:
+    types:
+      - opened
+      - edited
+      - deleted
+      - transferred
+      - closed
+      - reopened
 
 jobs:
   blocking_issues:


### PR DESCRIPTION
## Description

This PR adds a new feature to PRs in this GitHub repository.
A PR can depend on:
- **another PR** from the same repository
- a GitHub issue from the same repository

To indicate that PR2 depends on PR1,
add **`Blocked by #1`** to PR2's description

This PR adds a new GitHub workflow (`.github/workflows/pr-dependencies-check.yml`) using the [Levi-Lesches/blocking-issues](https://github.com/Levi-Lesches/blocking-issues) GitHub Action. 
It runs each time a PR is created, updated, closed, or re-opened.
It checks if the PR is blocked. 
If so it fails, preventing the PR from being merged. 

⏱️ The workflow takes ~10 seconds to run.


## Remarks

### PR Dependent on another PR

✅ This works fine provided both PRs are in the same repository.
Cross-repository PR dependencies are not supported.

### PR Dependent on an Issue 

~~I experimented with making a PR dependent on a **GitHub Issue**.
Based on my testing, it does not work as closing this issue does not trigger the workflow. 
Therefore this dependency change is not taken into account automatically. 
I needed to edit the PR description to trigger the workflow again which is not optimal!  
❌ This is why, I do not recommend making a PR dependent on a GH issue.~~

**EDIT:** ✅ It now works fine. I made a mistake and the indentation was off. Now fixed.  

## Resources

- `Levi-Lesches/blocking-issues` GitHub Action: https://github.com/Levi-Lesches/blocking-issues
- Discussion about the need for such a feature in GitHub and the open-source workarounds in the meantime: https://github.com/orgs/community/discussions/4477#discussioncomment-1039627