### PR TITLE
💚 Hot Fix CORS error in publish GH action workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,8 @@ jobs:
         if: steps.playwright.outputs.cache-hit != 'true'
         run: playwright install --with-deps chromium
 
-      - name: Build Website and PDF
-        run: MKDOCS_EXPORTER_PDF=true mkdocs build
+      - name: Build Website
+        run: mkdocs build
 
       - name: Push Website to gh-pages Branch
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
This PR disables PDF generation temporarily.
The publish GitHub Action workflow fails because of a CORS issue that will be investigated later.
In the meantime, this will allow the website to be published.

```
ERROR   -  [mkdocs-exporter.pdf.browser] (error) Pump, CGM, Watch - TrioDocs

Access to font at 'https://unpkg.com/mathjax@3.2.2/es5/output/chtml/fonts/woff-v2/MathJax_Script-Regular.woff' (redirected from 'https://unpkg.com/mathjax@3/es5/output/chtml/fonts/woff-v2/MathJax_Script-Regular.woff')
from origin 'file://' has been blocked by CORS policy: 
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

EDIT:
This PR is a workaround.
PR #98 will fix the root cause.