### PR TITLE
✏️ Fix broken links on the translation page

### DIFF
--- a/docs/resources/translate.md
+++ b/docs/resources/translate.md
@@ -5,57 +5,57 @@
 Click on a language on the links below to turn on Google's automatic translation.
 
 
-[عربي](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=ar)
+[عربي](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ar)
 
-[Български](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=bg)
+[Български](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=bg)
 
-[Čeština](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=cs)
+[Čeština](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=cs)
 
-[Deutsch](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=de)
+[Deutsch](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=de)
 
-[Dansk](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=da)
+[Dansk](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=da)
 
-[Ελληνικά](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=el)
+[Ελληνικά](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=el)
 
-[Español](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=es)
+[Español](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=es)
 
-[日本](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=ja)
+[日本](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ja)
 
-[Suomi](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=fi)
+[Suomi](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fi)
 
-[Français](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=fr)
+[Français](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fr)
 
-[עברית](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=iw)
+[עברית](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=iw)
 
-[Hrvatski](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=hr)
+[Hrvatski](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hr)
 
-[हिंदी](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=hi)
+[हिंदी](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi)
 
-[Italiano](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=it)
+[Italiano](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=it)
 
-[한국어](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=ko)
+[한국어](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ko)
 
-[Norsk](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=no)
+[Norsk](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=no)
 
-[Nederlands](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=nl)
+[Nederlands](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=nl)
 
-[Polski](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=pl)
+[Polski](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pl)
 
-[Português](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=pt)
+[Português](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pt)
 
-[Română](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=ro)
+[Română](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ro)
 
-[Русский](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=ru)
+[Русский](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ru)
 
-[Slovenčina](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=sk)
+[Slovenčina](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sk)
 
-[Svenska](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=sv)
+[Svenska](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sv)
 
-[Turkish](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=tr)
+[Turkish](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=tr)
 
-中文（[简体](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=zh-CN))
+中文（[简体](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-CN))
 
-中文（[繁體](https://docs-diy--trio-org.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=zh-TW))
+中文（[繁體](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-TW))
 
 
 ## Change Language


### PR DESCRIPTION
This PR updates the links on the translate page.
It removes the former Sphinx suffix `en/latest/`.