### PR TITLE
📝 Display a link to the `Trio` GitHub repository instead of TrioDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,7 @@ extra_javascript:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/nightscout/trio-docs
+      link: https://github.com/nightscout/Trio
       name: Trio on GitHub
     - icon: fontawesome/brands/discord
       link: https://discord.gg/FnwFEFUwXE

--- a/overrides/partials/source.html
+++ b/overrides/partials/source.html
@@ -1,0 +1,8 @@
+{#- Override mkdocs-material theme to show the nightscout/Trio GitHub repository instead nightscout/trio-docs -#}
+<a href="https://github.com/nightscout/Trio/" title="{{ lang.t('source') }}" class="md-source" data-md-component="source">
+  <div class="md-source__icon md-icon">
+    {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %} {%
+    include ".icons/" ~ icon ~ ".svg" %}
+  </div>
+  <div class="md-source__repository">nightscout/Trio</div>
+</a>


### PR DESCRIPTION
This PR updates the link to the GitHub repository to point to `nightscout/Trio` (the main project) instead of `nightscout/trio-docs` (the documentation).
 
It overrides a template (HTML snippet) used in the header, footer, and navigation (on small screens) to display the link to the Github repository.

Fixes #92