### PR TITLE
Remove iAPS repository link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Trio is an automated insulin delivery system for iOS based on the [OpenAPS algor
 The project started as Ivan Valkou's [FreeAPS X](https://github.com/ivalkou/freeaps) implementation of the OpenAPS algorithm for iPhone and later forked and rebranded as iAPS.
 Since then, many developers have contributed substantial work, leading to a range of new features and enhancements.
 
-Following the release of version 3.0.0, the project's direction significantly changed due to differing views on development, open source, and peer review. This led to the separation from the [Artificial-Pancreas/iAPS](https://github.com/Artificial-Pancreas/iAPS) repository and the birth of Trio as a distinct entity. This transition marks the project's new phase, symbolizing its evolution and the collaborative development's dynamic nature.
+Following the release of version 3.0.0, the project's direction significantly changed due to differing views on development, open source, and peer review. This led to the separation from the iAPS repository and the birth of Trio as a distinct entity. This transition marks the project's new phase, symbolizing its evolution and the collaborative development's dynamic nature.
 
 Trio continues to leverage a variety of frameworks from the DIY looping community and remains at the forefront of DIY diabetes management solutions, constantly evolving with valuable contributions from its community.
 


### PR DESCRIPTION
New users can and have followed this link intending to build Trio and built the wrong app.

To prevent user confusion, the link to the iAPS repository on the home screen (index.md) has been removed. The information regarding the origins of Trio is still present, but the link in the documentation is removed.