### PR TITLE
✏️ Fix typo in "OpenAPS Main Settings" page

### DIFF
--- a/docs/Configuration/transition-qa.md
+++ b/docs/Configuration/transition-qa.md
@@ -57,11 +57,15 @@ iOS Loop uses different algorithms, meaning it has a different approach than Tri
 
 ??? note "Incorrect or missing carb entries"
     
-    Trio has a feature called Unannounced Meals (UAM). With this option enabled and properly configured, Trio will react to rising BG by giving insulin through a Super Micro Bolus (SMB) even if no carbohydrates are registered. UAM helps in two scenarios: forgetting to add carbohydrates for a meal and entering carbohydrates but not the correct amount.
-
-??? note "Lots of manual corrections and "fake carbs"
+    *Trio* has a feature called Unannounced Meals (*UAM*). With this option enabled and properly configured, Trio will react to rising BG by giving insulin through a Super Micro Bolus (*SMB*) even if no carbohydrates are registered.  
+    *UAM* helps in two scenarios: 
     
-    With UAM and SMB active and properly configured, Trio will make any necessary corrections. There is no need to add "fake carbs" to make Trio give insulin, as many Loop users are used to.
+    - when you have neglected to add carbohydrates for a meal
+    - when you have entered carbohydrates but not the correct amount.
+
+??? note "Lots of manual corrections and "fake carbs""
+    
+    With *UAM* and *SMB* active and properly configured, Trio will make any necessary corrections. There is no need to add "fake carbs" to make Trio give insulin, as many Loop users are used to.
 
 ??? note "Persistent highs because of variations in Insulin Sensitivity Factor (ISF) and Insulin-to-Carbohydrate Ratio (CR)"
     

--- a/docs/settings/configuration/preferences/mainsettings.md
+++ b/docs/settings/configuration/preferences/mainsettings.md
@@ -46,13 +46,13 @@ You can start by increasing this number to your average mealtime bolus and evalu
     Using the **MaxIOB** formula
     
     $$
-    Average\ Meal\ Bolus + 3 \times Highest\ Hourly\ Basal
+    Average\ Meal\ Bolus + (3 \times Highest\ Hourly\ Basal)
     $$
     
     his recommended **Max IOB** setting should be **12**
     
     $$
-    6 + 3 \times 2.0 = 12
+    6 + ( 3 \times 2.0 ) = 12
     $$
 
 If you are insulin resistant and/or need help dealing with meal spikes, you can continue to increase this number further to allow for greater insulin delivery.
@@ -136,4 +136,4 @@ This setting determines the minimum ratio autosens can use for its adjustments. 
 This limits the ability of Dynamic ISF and Dynamic CR to reduce insulin needs.
 
 ### Autosens Min with Autotune
-This setting Autotune's ability to reduce insulin needs in your CR, basal profile, and ISF.
+This setting limits Autotune's ability to reduce insulin needs in your CR, basal profile, and ISF.


### PR DESCRIPTION
This PR fixes typos in the "_OpenAPS Main Settings_" and "_Transition from other closed-loop solutions_" pages.

👍 Thank you Ellen and Tina 🦅 👁️.

Source: Slack ([here](https://loopandlearneditors.slack.com/archives/C071VLH3PE0/p1732457215109609) and [there](https://loopandlearneditors.slack.com/archives/C071VLH3PE0/p1731983512911409))