### PR TITLE
📝 Add Remote Caregivers and Missing Red Loop to Nightscout Page

### DIFF
--- a/docs/settings/services/nightscout.md
+++ b/docs/settings/services/nightscout.md
@@ -44,7 +44,3 @@ The signature for this situation when viewing the *Nightscout* display is either
 2. 📉 or falling glucose with no temporary basal set to `0 U/hr`.
 
 
-!!! important "LoopFollow and Trio Limitations in Detecting Lost Pod Communication"
-    
-    *[LoopFollow](https://www.loopandlearn.org/loop-follow/)* for *Trio* version `0.2.3` or earlier does not alert for lost Pod communications because *Nightscout* does not alert.
-

--- a/docs/settings/services/nightscout.md
+++ b/docs/settings/services/nightscout.md
@@ -17,3 +17,32 @@ with another person, it will be helpful for you to visualize what the loop is do
 
 ## Trio Setup
 To enable your nightscout connection, input your Nightscout URL, including the `https://` and your `API_SECRET`. Select `Allow uploads` so Trio can share its predictions and settings with Nightscout. 
+
+    
+## Remote Caregivers and Missing Red Loop in Nightscout
+
+!!! warning "Remote Caregivers and Missing Red Loop in Nightscout"
+    
+    Read this section if you are using **_Trio_** version **`0.2.3` or earlier**.
+
+### Why the “Red Loop” Indicator is Missing in Nightscout
+
+When using **_Nightscout_ version `15.0.2` (and earlier)**, a caregiver looking at a *Trio* site will not see a “red loop” indication on *Nightscout* when the *Trio* phone is still getting glucose readings, but the *Pod* is disconnected (because of a communication issue or if it is deactivated). Even if the *Trio* phone clearly indicates the *Pod* issue, a remote viewer needs to know how to recognize this situation.
+
+### How to Recognize a Disconnected Pod in Nightscout
+
+The caregiver will see predictions continue, but no sign of extra insulin delivered for rising glucose or withheld for falling glucose.
+
+- If it is a matter of **communication problem** (and the *Pod* is still active),  
+  then the *Pod* will return to scheduled basal rates when any active temporary basal duration ends. 
+- If it is a matter of a **_Pod_ fault or removal without applying a new _Pod_**,  
+  the rate of glucose increase may be pretty steep.  
+
+The signature for this situation when viewing the *Nightscout* display is either:
+   
+1. 📈 rising glucose with no increase in temporary basal rates or application of manual bolus or SMB,
+2. 📉 or falling glucose with no temporary basal set to `0 U/hr`.
+
+### Workaround
+
+ℹ️ For those who can use *[LoopFollow](https://www.loopandlearn.org/loop-follow/)*, version **`2.2.9`** has an updated "Not Looping" indicator with an optional alarm that works with *Trio*.

--- a/docs/settings/services/nightscout.md
+++ b/docs/settings/services/nightscout.md
@@ -43,6 +43,8 @@ The signature for this situation when viewing the *Nightscout* display is either
 1. 📈 rising glucose with no increase in temporary basal rates or application of manual bolus or SMB,
 2. 📉 or falling glucose with no temporary basal set to `0 U/hr`.
 
-### Workaround
 
-ℹ️ For those who can use *[LoopFollow](https://www.loopandlearn.org/loop-follow/)*, version **`2.2.9`** has an updated "Not Looping" indicator with an optional alarm that works with *Trio*.
+!!! important "LoopFollow and Trio Limitations in Detecting Lost Pod Communication"
+    
+    *[LoopFollow](https://www.loopandlearn.org/loop-follow/)* for *Trio* version `0.2.3` or earlier does not alert for lost Pod communications because *Nightscout* does not alert.
+


### PR DESCRIPTION
This PR updates the _Nightscout_ page to explain:

- Why and when _Nightscout_ does not show a "red loop" when _Trio_ 0.2.3 or earlier is still getting glucose readings, but the _Pod_ is disconnected
- How to Recognize a Disconnected Pod in Nightscout
- ~~Possible Workaround~~

Source: https://loopandlearneditors.slack.com/archives/C071VLH3PE0/p1738423655800939