### PR TITLE
Publish docs for Trio v0.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
   # Remark: Next 5 lines triggers the workflow on push events for the main branch
   push:
     branches:
-      - dev
+      - docs-0.4.0
     paths-ignore:
       - "README.md"
 


### PR DESCRIPTION
This changes `publish.yml` to publish from a new branch `docs-0.4.0` instead of `dev`.

This will update `https://docs.diy-trio.org` ahead of the soon-to-be-released open-beta (v0.4.0).

The `docs-0.4.0` branch was developed by a collaboration in a private repo, where all iterations went through reviews and approvals.