### PR TITLE
Fix typo, `cgm` ==> `CGM`

### DIFF
--- a/docs/configuration/settings/algorithm/additionals.md
+++ b/docs/configuration/settings/algorithm/additionals.md
@@ -175,11 +175,11 @@ In combination with the previous setting, Trio will limit the number of carbs th
 **Default:** _130%_  
 **Setting Limits:** _100%-200%_
 
-This setting raises your glucose target by this percent of your current target glucose when cgm readings are fluctuating widely.
+This setting raises your glucose target by this percent of your current target glucose when CGM readings are fluctuating widely.
 
 This helps reduce the risk of incorrect insulin fosing based on inaccurate sensor data, ensuring safer insulin adjustments during periods of poor CGM accuracy.
 
-??? question "Bill has a Dexcom G7 and his cgm readings are very jumpy for the first 24 hours. His current glucose target is 110 mg/dL (6.1 mmol/L). What will Trio adjust his target glucose to in order to prevent extra, unnecessary insulin?"
+??? question "Bill has a Dexcom G7 and his CGM readings are very jumpy for the first 24 hours. His current glucose target is 110 mg/dL (6.1 mmol/L). What will Trio adjust his target glucose to in order to prevent extra, unnecessary insulin?"
     
     ??? info "Here is the formula you will need:"
         

--- a/docs/configuration/settings/devices/cgm.md
+++ b/docs/configuration/settings/devices/cgm.md
@@ -9,7 +9,7 @@ The first step in setting up your continuous glucose monitor (CGM) on Trio is to
 {align=center}
 
 ## Step 2: Select Your CGM
-Select your cgm from the in-app menu and from the options below for step by step instructions. The links below will guide you through the connection instructions for your specific cgm:  
+Select your CGM from the in-app menu and from the options below for step by step instructions. The links below will guide you through the connection instructions for your specific CGM:  
 
 - [Dexcom G5/Dexcom G6/Dexcom ONE](#dexcom-g5-and-dexcom-g6dexcom-one)
 - [Dexcom G7/Dexcom ONE+](#dexcom-g7dexcom-one)
@@ -57,7 +57,7 @@ Continue to [Connect Watch](smart-watch.md) _OR_ return to [New User Setup](../.
 - - -
 
 ### Freestyle Libre
-This option can be used to pair a compatible Libre cgm directly to Trio without going through a separate app like xDrip4iOS.
+This option can be used to pair a compatible Libre CGM directly to Trio without going through a separate app like xDrip4iOS.
 
 **Step 3**
 Tap "Libre 2 Direct" to use Libre 2 sensors or "Bluetooth Transmitters" to use Libre 1 sensors with a Miao Miao or other 3rd party transmitter.
@@ -122,7 +122,7 @@ Continue to [Connect Watch](smart-watch.md) _OR_ return to [New User Setup](../.
 - - -
 
 ### xDrip4iOS
-To use xDrip4iOS as a cgm source, you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use Shuggah or a version distributed by someone else's TestFlight. Please see the following for instructions on how to build xDrip4iOS yourself: [link](../../../install/ecosystem/xdrip4ios.md)
+To use xDrip4iOS as a CGM source, you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use Shuggah or a version distributed by someone else's TestFlight. Please see the following for instructions on how to build xDrip4iOS yourself: [link](../../../install/ecosystem/xdrip4ios.md)
 
 However, if you are using Dexcom G6 or ONE with xDrip4iOS, you can choose the Dexcom G6 option in Trio rather than xDrip4iOS, and Trio will intercept the glucose readings even if you're using Shuggah or someone else's TestFlight of xDrip4iOS.
 

--- a/docs/install/build/requirements/devices/cgm.md
+++ b/docs/install/build/requirements/devices/cgm.md
@@ -32,7 +32,7 @@ Remember to enable `Upload Readings` to have *Trio* send glucose to *Nightscout*
 Trio can intercept its glucose readings as long as the Dexcom G7 or ONE app is installed on the same phone. When a new G7 sensor is paired to the Dexcom G7 app, or a new ONE+ sensor is paired to the Dexcom ONE+ app, Trio will automatically start reading it.
 
 ## Glucose Simulator
-The Glucose Simulator adds artificial CGM readings to the screen so you can see how your readings might look in the app. When using this CGM option, you cannot manually influence the readings shown to reflect a desired glucose response. Actions taken by the Trio algorithm also do not affect the cgm readings in the Glucose Simulator. They are for visual purposes only. For this reason, using the Glucose Simulator will not help you understand how the algorithm influences blood sugars.
+The Glucose Simulator adds artificial CGM readings to the screen so you can see how your readings might look in the app. When using this CGM option, you cannot manually influence the readings shown to reflect a desired glucose response. Actions taken by the Trio algorithm also do not affect the CGM readings in the Glucose Simulator. They are for visual purposes only. For this reason, using the Glucose Simulator will not help you understand how the algorithm influences blood sugars.
 
 !!! warning
     

--- a/docs/usage/interface.md
+++ b/docs/usage/interface.md
@@ -35,7 +35,7 @@ Use the tabs below to learn more about each section:
     {align="center"}
     
     !!! tip "Pro Tip"
-        If you long press the bobble, it will snooze cgm alerts
+        If you long press the bobble, it will snooze CGM alerts
     
 === "Pump Info"
 


### PR DESCRIPTION
This PR fixes typos, replacing `cgm` with `CGM`.