### PR TITLE
Migration Charts for Settings from iAPS to Trio

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -19,4 +19,10 @@ Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome
     
     A compilation of all settings found in Trio with explanations and definitions
 
+-   __[Migration from other OS-AIDs](migration/index.md)__
+
+    - - -
+    
+    Guidance on locating and identifying the necessary settings for onboarding
+
 </div>

--- a/docs/configuration/migration/aaps-migration.md
+++ b/docs/configuration/migration/aaps-migration.md
@@ -1,0 +1,3 @@
+# Coming from AAPS ✏️
+🚧 Documentation Under Construction 🚧
+<!--todo-->

--- a/docs/configuration/migration/iaps-migration.md
+++ b/docs/configuration/migration/iaps-migration.md
@@ -1,0 +1,71 @@
+# Coming from iAPS
+
+When you move your settings from iAPS to Trio, some of them might look different even if they have the same or similar names. That’s because we changed some of the numbers from decimals to percentages to make them easier to understand.
+
+!!! example
+    In iAPS you might set "Autosens Maximum" to 1.2. In Trio, we show "Autosens Max" as 120%, which means the same thing, but is easier to understand.
+
+Some setting names have also changed. We did this to make things less confusing. To help you out, we added definitions right in the app. Just tap the question mark icon next to any setting to see what it means. Healthcare Professionals and users can also find those settings and explanations [in this section of the docs](../settings/index.md).
+
+In iAPS, some settings had limits (called guardrails) that weren’t always visible, and others had no limits at all. In Trio, we’ve made those guardrails easier to see and added a few more where needed, to help prevent settings that could lead to unsafe outcomes.
+
+The charts below will help you see which setting names or formats have changed, and where to find them in both iAPS and Trio.
+
+!!! tip
+    To convert a value from a decimal to a percentage, multiply it by 100.  
+    To conver from a percentage to a decimal, divide by 100.
+
+## Prepare Trio
+
+| Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| **[Glucose Units](settings/therapy/units-limits.md#glucose-units)** | selection <br> (mg/dL or mmol/L) | Settings → Therapy → Units and Limits | **Target Glucose** | selection <br> (mg/dL or mmol/L) | Settings → OpenAPS → Glucose units |
+
+## Therapy Settings
+
+| Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| **[Glucose Targets](../settings/therapy/glucose-targets.md#how-to-enter-your-glucose-targets-into-trio)** | decimal <br> (100 mg/dL &#124; 5.5 mmol/L) | Settings → Therapy → Glucose Targets | **Target Glucose** | decimal <br> (100 mg/dL &#124; 5.5 mmol/L) | Settings → Target Glucose |
+| **[Basal Rates](../settings/therapy/basal-rates.md#how-to-enter-your-basal-profiles-into-trio)** | decimal <br> (1.0 U/hr) | Settings → Therapy → Basal Rates | **Basal Profile** | decimal <br> (1.0 U/hr) | Settings → Basal Profile | 
+| **[Carb Ratios](../settings/therapy/carb-ratios.md#how-to-enter-your-carb-ratios-cr-into-trio)** | decimal <br> (10 g/U) | Settings → Therapy → Carb Ratios | **Carb Ratios** | decimal <br> (10 g/U) | Settings → Carb Ratios | 
+| **[Insulin Sensitivities](../settings/therapy/isf.md#how-to-enter-your-isf-into-trio)** | decimal <br> (54 mg/dL/U &#124; 3.0 mmol/L/U) | Settings → Therapy → Insulin Sensitivities | **Insulin Sensitivities** | decimal <br> (54 mg/dL/U &#124; 3.0 mmol/L/U) | Settings → Insulin Sensitivities | 
+
+## Delivery Limits
+
+| Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| **[Max IOB](../settings/therapy/units-limits.md#max-iob)** | decimal <br> (0 U) | Settings → Therapy → Units and Limits → Max IOB | **Max IOB** | decimal <br> (0) | Settings → OpenAPS → Max IOB |
+| **[Max Bolus](../settings/therapy/units-limits.md#max-bolus)** | decimal <br> (10 U) | Settings → Therapy → Units and Limits → Max Bolus | **Max Bolus** | decimal <br> (10) | Settings → Pump Settings → Max Bolus |
+| **[Max Basal Rate](../settings/therapy/units-limits.md#max-basal)** | decimal <br> (2 U/hr) | Settings → Therapy → Units and Limits → Max Basal Rate | **Max Basal** | decimal <br> (2) | Settings → Pump Settings → Max Bolus |
+| **[Max COB](../settings/therapy/units-limits.md#max-cob)** | decimal <br> (120 g) | Settings → Therapy → Units and Limits → Max COB | **Max COB** | decimal <br> (120) | Settings → OpenAPS → Max COB |
+| **[Minimum Safety Threshold](../settings/therapy/units-limits.md#minimum-safety-threshold)** | decimal <br> (60 mg/dL) | Settings → Therapy → Units and Limits → Max IOB | **Threshold Setting** | decimal <br> (60) | Settings → Dynamic ISF → Threshold Setting |
+
+## Algorithm Settings
+
+### [Autosens](../settings/algorithm/autosens.md)
+
+| Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| [**Autosens Min**](../settings/algorithm/autosens.md#autosens-min) | percentage <br> (70%) | Settings → Algorithm → Autosens → Autosens Min | **Autosens Minimum** | decimal <br> (0.7) | Settings → OpenAPS → Autosens Minimum |
+| [**Autosens Max**](../settings/algorithm/autosens.md#autosens-max) | percentage <br> (120%) | Settings → Algorithm → Autosens → Autosens Max | **Autosens Maximum** | decimal <br> (1.2) | Settings → OpenAPS → Autosens Maximum |
+
+### [SMB (Super Micro Bolus)](../settings/algorithm/smb-settings.md)
+
+| Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| [**Enable SMB Always**](../settings/algorithm/smb-settings.md#enable-smb-always) | toggle <br> (On/Off) | Settings → Algorithm → Super Micro Bolus (SMB) → Enable SMB Always | **Enable SMB Always** | toggle <br> (On/Off) | Settings → OpenAPS → Enable SMB Always |
+| [**Allow SMB with High Temp Target**](../settings/algorithm/smb-settings.md#allow-smb-with-high-temptarget) | toggle <br> (On/Off) | Settings → Algorithm → Super Micro Bolus (SMB) → Allow SMB With High Temptarget | **Allow SMB With High Temptarget** | toggle <br> (On/Off) | Settings → OpenAPS → Allow SMB With High Temptarget |
+| [**Enable UAM**](../settings/algorithm/smb-settings.md#enable-uam) | toggle <br> (On/Off) | Settings → Algorithm → Super Micro Bolus (SMB) → Enable UAM | **Enable UAM** | toggle <br> (On/Off) | Settings → OpenAPS → Enable UAM |
+| [**Max SMB Basal Minutes**](settings/algorithm/smb-settings.md#max-smb-basal-minutes) | decimal <br> (30 min) | Settings → Algorithm → Super Micro Bolus (SMB) → Max SMB Basal Minutes | **Enable UAM** | decimal <br> (30) | Settings → OpenAPS → Max SMB Basal Minutes |
+| [**Max UAM Basal Minutes**](settings/algorithm/smb-settings.md#max-uam-basal-minutes) | decimal <br> (30 min) | Settings → Algorithm → Super Micro Bolus (SMB) → Max UAM Basal Minutes | **Max UAM SMB Basal Minutes** | decimal <br> (30) | Settings → OpenAPS → Max UAM SMB Basal Minutes |
+| [**Max Delta-BG Threshold SMB**](settings/algorithm/smb-settings.md#max-delta-bg-threshold-smb) | percentage <br> (20%) | Settings → Algorithm → Super Micro Bolus (SMB) → Max Delta-BG Threshold SMB | **Max Delta-BG Threshold SMB** | decimal <br> (0.2) | Settings → OpenAPS → Max Delta-BG Threshold SMB |
+
+### [Target Behavior](../settings/algorithm/target-behavior.md)
+
+| Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| [**High Temp Target Raises Sensitivity**](settings/algorithm/target-behavior.md#high-temp-target-raises-sensitivity) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → High Temp Target Raises Sensitivity | **High Temptarget Raises Sensitivity** | toggle <br> (On/Off) | Settings → OpenAPS → High Temptarget Raises Sensitivity |
+| [**Low Temp Target Lowers Sensitivity**](settings/algorithm/target-behavior.md#low-temp-target-lowers-sensitivity) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Low Temp Target Lowers Sensitivity | **Low Temptarget Lowers Sensitivity** | toggle <br> (On/Off) | Settings → OpenAPS → Low Temptarget Lowers Sensitivity |
+| [**Sensitivity Raises Target**](settings/algorithm/target-behavior.md#sensitivity-raises-target) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Sensitivity Raises Target | **Sensitivity Raises Target** | toggle <br> (On/Off) | Settings → OpenAPS → Sensitivity Raises Target |
+| [**Resistance Lowers Target**](settings/algorithm/target-behavior.md#resistance-lowers-target) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Resistance Lowers Target | **Resistance Lowers Target** | toggle <br> (On/Off) | Settings → OpenAPS → Resistance Lowers Target |
+| [**Half Basal Exercise Target**](settings/algorithm/target-behavior.md#half-basal-exercise-target) | decimal <br> (160 mg/dL &#124; 8.9 mmol/L) | Settings → Algorithm → Target Behavior → Half Basal Exercise Target | **Half Basal Exercise Target** | decimal <br> (160 mg/dL &#124; 8.9 mmol/L) | Settings → OpenAPS → Half Basal Exercise Target |

--- a/docs/configuration/migration/iaps-migration.md
+++ b/docs/configuration/migration/iaps-migration.md
@@ -13,32 +13,32 @@ The charts below will help you see which setting names or formats have changed, 
 
 !!! tip
     To convert a value from a decimal to a percentage, multiply it by 100.  
-    To conver from a percentage to a decimal, divide by 100.
+    To convert from a percentage to a decimal, divide by 100.
 
 ## Prepare Trio
 
 | Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
 |:---:|:---:|:---:|:---:|:---:|:---:|
-| **[Glucose Units](settings/therapy/units-limits.md#glucose-units)** | selection <br> (mg/dL or mmol/L) | Settings → Therapy → Units and Limits | **Target Glucose** | selection <br> (mg/dL or mmol/L) | Settings → OpenAPS → Glucose units |
+| [**Glucose Units**](../settings/therapy/units-limits.md#glucose-units) | selection <br> (mg/dL or mmol/L) | Settings → Therapy → Units and Limits | **Target Glucose** | selection <br> (mg/dL or mmol/L) | Settings → OpenAPS → Glucose units |
 
 ## Therapy Settings
 
 | Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
 |:---:|:---:|:---:|:---:|:---:|:---:|
-| **[Glucose Targets](../settings/therapy/glucose-targets.md#how-to-enter-your-glucose-targets-into-trio)** | decimal <br> (100 mg/dL &#124; 5.5 mmol/L) | Settings → Therapy → Glucose Targets | **Target Glucose** | decimal <br> (100 mg/dL &#124; 5.5 mmol/L) | Settings → Target Glucose |
-| **[Basal Rates](../settings/therapy/basal-rates.md#how-to-enter-your-basal-profiles-into-trio)** | decimal <br> (1.0 U/hr) | Settings → Therapy → Basal Rates | **Basal Profile** | decimal <br> (1.0 U/hr) | Settings → Basal Profile | 
-| **[Carb Ratios](../settings/therapy/carb-ratios.md#how-to-enter-your-carb-ratios-cr-into-trio)** | decimal <br> (10 g/U) | Settings → Therapy → Carb Ratios | **Carb Ratios** | decimal <br> (10 g/U) | Settings → Carb Ratios | 
-| **[Insulin Sensitivities](../settings/therapy/isf.md#how-to-enter-your-isf-into-trio)** | decimal <br> (54 mg/dL/U &#124; 3.0 mmol/L/U) | Settings → Therapy → Insulin Sensitivities | **Insulin Sensitivities** | decimal <br> (54 mg/dL/U &#124; 3.0 mmol/L/U) | Settings → Insulin Sensitivities | 
+| [**Glucose Targets**](../settings/therapy/glucose-targets.md#how-to-enter-your-glucose-targets-into-trio) | decimal <br> (100 mg/dL &#124; 5.5 mmol/L) | Settings → Therapy → Glucose Targets | **Target Glucose** | decimal <br> (100 mg/dL &#124; 5.5 mmol/L) | Settings → Target Glucose |
+| [**Basal Rates**](../settings/therapy/basal-rates.md#how-to-enter-your-basal-profiles-into-trio) | decimal <br> (1.0 U/hr) | Settings → Therapy → Basal Rates | **Basal Profile** | decimal <br> (1.0 U/hr) | Settings → Basal Profile | 
+| [**Carb Ratios**](../settings/therapy/carb-ratios.md#how-to-enter-your-carb-ratios-cr-into-trio) | decimal <br> (10 g/U) | Settings → Therapy → Carb Ratios | **Carb Ratios** | decimal <br> (10 g/U) | Settings → Carb Ratios | 
+| [**Insulin Sensitivities**](../settings/therapy/isf.md#how-to-enter-your-isf-into-trio) | decimal <br> (54 mg/dL/U &#124; 3.0 mmol/L/U) | Settings → Therapy → Insulin Sensitivities | **Insulin Sensitivities** | decimal <br> (54 mg/dL/U &#124; 3.0 mmol/L/U) | Settings → Insulin Sensitivities | 
 
 ## Delivery Limits
 
 | Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
 |:---:|:---:|:---:|:---:|:---:|:---:|
-| **[Max IOB](../settings/therapy/units-limits.md#max-iob)** | decimal <br> (0 U) | Settings → Therapy → Units and Limits → Max IOB | **Max IOB** | decimal <br> (0) | Settings → OpenAPS → Max IOB |
-| **[Max Bolus](../settings/therapy/units-limits.md#max-bolus)** | decimal <br> (10 U) | Settings → Therapy → Units and Limits → Max Bolus | **Max Bolus** | decimal <br> (10) | Settings → Pump Settings → Max Bolus |
-| **[Max Basal Rate](../settings/therapy/units-limits.md#max-basal)** | decimal <br> (2 U/hr) | Settings → Therapy → Units and Limits → Max Basal Rate | **Max Basal** | decimal <br> (2) | Settings → Pump Settings → Max Bolus |
-| **[Max COB](../settings/therapy/units-limits.md#max-cob)** | decimal <br> (120 g) | Settings → Therapy → Units and Limits → Max COB | **Max COB** | decimal <br> (120) | Settings → OpenAPS → Max COB |
-| **[Minimum Safety Threshold](../settings/therapy/units-limits.md#minimum-safety-threshold)** | decimal <br> (60 mg/dL) | Settings → Therapy → Units and Limits → Max IOB | **Threshold Setting** | decimal <br> (60) | Settings → Dynamic ISF → Threshold Setting |
+| [**Max IOB**](../settings/therapy/units-limits.md#max-iob) | decimal <br> (2 U) | Settings → Therapy → Units and Limits → Max IOB | **Max IOB** | decimal <br> (2) | Settings → OpenAPS → Max IOB |
+| [**Max Bolus**](../settings/therapy/units-limits.md#max-bolus) | decimal <br> (10 U) | Settings → Therapy → Units and Limits → Max Bolus | **Max Bolus** | decimal <br> (10) | Settings → Pump Settings → Max Bolus |
+| [**Max Basal Rate](../settings/therapy/units-limits.md#max-basal) | decimal <br> (2 U/hr) | Settings → Therapy → Units and Limits → Max Basal Rate | **Max Basal** | decimal <br> (2) | Settings → Pump Settings → Max Bolus |
+| [**Max COB**](../settings/therapy/units-limits.md#max-cob) | decimal <br> (120 g) | Settings → Therapy → Units and Limits → Max COB | **Max COB** | decimal <br> (120) | Settings → OpenAPS → Max COB |
+| [**Minimum Safety Threshold**](../settings/therapy/units-limits.md#minimum-safety-threshold) | decimal <br> (60 mg/dL) | Settings → Therapy → Units and Limits → Max IOB | **Threshold Setting** | decimal <br> (60) | Settings → Dynamic ISF → Threshold Setting |
 
 ## Algorithm Settings
 
@@ -56,16 +56,16 @@ The charts below will help you see which setting names or formats have changed, 
 | [**Enable SMB Always**](../settings/algorithm/smb-settings.md#enable-smb-always) | toggle <br> (On/Off) | Settings → Algorithm → Super Micro Bolus (SMB) → Enable SMB Always | **Enable SMB Always** | toggle <br> (On/Off) | Settings → OpenAPS → Enable SMB Always |
 | [**Allow SMB with High Temp Target**](../settings/algorithm/smb-settings.md#allow-smb-with-high-temptarget) | toggle <br> (On/Off) | Settings → Algorithm → Super Micro Bolus (SMB) → Allow SMB With High Temptarget | **Allow SMB With High Temptarget** | toggle <br> (On/Off) | Settings → OpenAPS → Allow SMB With High Temptarget |
 | [**Enable UAM**](../settings/algorithm/smb-settings.md#enable-uam) | toggle <br> (On/Off) | Settings → Algorithm → Super Micro Bolus (SMB) → Enable UAM | **Enable UAM** | toggle <br> (On/Off) | Settings → OpenAPS → Enable UAM |
-| [**Max SMB Basal Minutes**](settings/algorithm/smb-settings.md#max-smb-basal-minutes) | decimal <br> (30 min) | Settings → Algorithm → Super Micro Bolus (SMB) → Max SMB Basal Minutes | **Enable UAM** | decimal <br> (30) | Settings → OpenAPS → Max SMB Basal Minutes |
-| [**Max UAM Basal Minutes**](settings/algorithm/smb-settings.md#max-uam-basal-minutes) | decimal <br> (30 min) | Settings → Algorithm → Super Micro Bolus (SMB) → Max UAM Basal Minutes | **Max UAM SMB Basal Minutes** | decimal <br> (30) | Settings → OpenAPS → Max UAM SMB Basal Minutes |
-| [**Max Delta-BG Threshold SMB**](settings/algorithm/smb-settings.md#max-delta-bg-threshold-smb) | percentage <br> (20%) | Settings → Algorithm → Super Micro Bolus (SMB) → Max Delta-BG Threshold SMB | **Max Delta-BG Threshold SMB** | decimal <br> (0.2) | Settings → OpenAPS → Max Delta-BG Threshold SMB |
+| [**Max SMB Basal Minutes**](../settings/algorithm/smb-settings.md#max-smb-basal-minutes) | decimal <br> (30 min) | Settings → Algorithm → Super Micro Bolus (SMB) → Max SMB Basal Minutes | **Enable UAM** | decimal <br> (30) | Settings → OpenAPS → Max SMB Basal Minutes |
+| [**Max UAM Basal Minutes**](../settings/algorithm/smb-settings.md#max-uam-basal-minutes) | decimal <br> (30 min) | Settings → Algorithm → Super Micro Bolus (SMB) → Max UAM Basal Minutes | **Max UAM SMB Basal Minutes** | decimal <br> (30) | Settings → OpenAPS → Max UAM SMB Basal Minutes |
+| [**Max Allowed Glucose Rise for SMB**](../settings/algorithm/smb-settings.md#max-allowed-glucose-rise-for-smb) | percentage <br> (20%) | Settings → Algorithm → Super Micro Bolus (SMB) → Max Allowed Glucose Rise for SMB | **Max Delta-BG Threshold SMB** | decimal <br> (0.2) | Settings → OpenAPS → Max Delta-BG Threshold SMB |
 
 ### [Target Behavior](../settings/algorithm/target-behavior.md)
 
 | Trio Name | Setting Format <br> (example) | Location in App | iAPS Name | Setting Format <br> (example) | Location in App |
 |:---:|:---:|:---:|:---:|:---:|:---:|
-| [**High Temp Target Raises Sensitivity**](settings/algorithm/target-behavior.md#high-temp-target-raises-sensitivity) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → High Temp Target Raises Sensitivity | **High Temptarget Raises Sensitivity** | toggle <br> (On/Off) | Settings → OpenAPS → High Temptarget Raises Sensitivity |
-| [**Low Temp Target Lowers Sensitivity**](settings/algorithm/target-behavior.md#low-temp-target-lowers-sensitivity) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Low Temp Target Lowers Sensitivity | **Low Temptarget Lowers Sensitivity** | toggle <br> (On/Off) | Settings → OpenAPS → Low Temptarget Lowers Sensitivity |
-| [**Sensitivity Raises Target**](settings/algorithm/target-behavior.md#sensitivity-raises-target) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Sensitivity Raises Target | **Sensitivity Raises Target** | toggle <br> (On/Off) | Settings → OpenAPS → Sensitivity Raises Target |
-| [**Resistance Lowers Target**](settings/algorithm/target-behavior.md#resistance-lowers-target) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Resistance Lowers Target | **Resistance Lowers Target** | toggle <br> (On/Off) | Settings → OpenAPS → Resistance Lowers Target |
-| [**Half Basal Exercise Target**](settings/algorithm/target-behavior.md#half-basal-exercise-target) | decimal <br> (160 mg/dL &#124; 8.9 mmol/L) | Settings → Algorithm → Target Behavior → Half Basal Exercise Target | **Half Basal Exercise Target** | decimal <br> (160 mg/dL &#124; 8.9 mmol/L) | Settings → OpenAPS → Half Basal Exercise Target |
+| [**High Temp Target Raises Sensitivity**](../settings/algorithm/target-behavior.md#high-temp-target-raises-sensitivity) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → High Temp Target Raises Sensitivity | **High Temptarget Raises Sensitivity** | toggle <br> (On/Off) | Settings → OpenAPS → High Temptarget Raises Sensitivity |
+| [**Low Temp Target Lowers Sensitivity**](../settings/algorithm/target-behavior.md#low-temp-target-lowers-sensitivity) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Low Temp Target Lowers Sensitivity | **Low Temptarget Lowers Sensitivity** | toggle <br> (On/Off) | Settings → OpenAPS → Low Temptarget Lowers Sensitivity |
+| [**Sensitivity Raises Target**](../settings/algorithm/target-behavior.md#sensitivity-raises-target) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Sensitivity Raises Target | **Sensitivity Raises Target** | toggle <br> (On/Off) | Settings → OpenAPS → Sensitivity Raises Target |
+| [**Resistance Lowers Target**](../settings/algorithm/target-behavior.md#resistance-lowers-target) | toggle <br> (On/Off) | Settings → Algorithm → Target Behavior → Resistance Lowers Target | **Resistance Lowers Target** | toggle <br> (On/Off) | Settings → OpenAPS → Resistance Lowers Target |
+| [**Half Basal Exercise Target**](../settings/algorithm/target-behavior.md#half-basal-exercise-target) | decimal <br> (160 mg/dL &#124; 8.9 mmol/L) | Settings → Algorithm → Target Behavior → Half Basal Exercise Target | **Half Basal Exercise Target** | decimal <br> (160 mg/dL &#124; 8.9 mmol/L) | Settings → OpenAPS → Half Basal Exercise Target |

--- a/docs/configuration/migration/index.md
+++ b/docs/configuration/migration/index.md
@@ -1,0 +1,15 @@
+# Migration from other OS-AIDs
+
+![Trio Logo](../../assets/images/trio-logo.png){ width="75", align="left"}
+Welcome to the Migration homepage! Here you will find guidance on locating and identifying the necessary settings needed to start using Trio. Select the app you are moving from in the list below.
+
+Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome-solid-magnifying-glass:, or the menu below to find the section you are looking for.
+
+<div class="grid cards" markdown>
+
+-   __[Trio 0.2.x ✏️](trio-02x-migration.md)__
+-   __[iAPS](iaps-migration.md)__
+-   __[Loop ✏️](loop-migration.md)__
+-   __[AndroidAPS ✏️](aaps-migration.md)__
+
+</div>

--- a/docs/configuration/migration/loop-migration.md
+++ b/docs/configuration/migration/loop-migration.md
@@ -1,0 +1,8 @@
+# Coming from Loop ✏️
+🚧 Documentation Under Construction 🚧
+<!--todo-->
+<!--Notes: be sure to add this info
+
+- Going from target range to singe target glucose
+
+-->

--- a/docs/configuration/migration/trio-02x-migration.md
+++ b/docs/configuration/migration/trio-02x-migration.md
@@ -1,0 +1,3 @@
+# Coming from Trio 0.2.x ✏️
+🚧 Documentation Under Construction 🚧
+<!--todo-->

--- a/docs/configuration/new-user-setup.md
+++ b/docs/configuration/new-user-setup.md
@@ -109,11 +109,19 @@ In this step, you'll configure diagnostics sharing, optionally sync with Nightsc
 
 The next step is to enter your Therapy Settings. These include:
 
-- **Target Glucose**: Trio's dosing will aim for this glucose when calculating insulin dosage
+- **Glucose Targets**: Trio's dosing will aim for this glucose when calculating insulin dosage
 - **Basal Rates**: Used as a baseline for increasing or decreasing insulin needs
 - **Carb Ratios**: How many grams of carbohydrate are countered by 1 unit of insulin
 - **Insulin Sensitivities**: How much 1 unit of insulin will lower your blood glucose
 
+!!! tip "Need help finding these settings in your current DIY app?"
+    If you are coming from another Open Source Automated Insulin Dosing (OS-AID) app, these guides may help you with finding these settings in your previous app and inputing them into Trio.
+    
+    - [Trio 0.2.x](migration/trio-02x-migration.md)
+    - [iAPS](migration/iaps-migration.md)
+    - [Loop](migration/loop-migration.md)
+    - [AndroidAPS](migration/aaps-migration.md)
+    
 <div class="grid" markdown>
 
 === "During Onboarding"

--- a/docs/configuration/new-user-setup.md
+++ b/docs/configuration/new-user-setup.md
@@ -37,25 +37,34 @@ Trio has an Onboarding Wizard that walks you through these steps when you first 
 
 [**Step 1:** Prepare Trio](#step-1-prepare-trio)
 
-[**Step 6:** Bluetooth](#step-6-bluetooth)
-
 [**Step 2:** Therapy Settings](#step-2-therapy-settings)
-
-[**Step 7:** Connect Your Devices](#step-7-connect-your-devices)
 
 [**Step 3:** Delivery Limits](#step-3-delivery-limits)
 
-[**Step 8:** Enable Closed Loop](#step-8-enable-closed-loop)
-
 [**Step 4:** Algorithm Settings](#step-4-algorithm-settings)
-
-[**Step 9:** Change App Icon (Optional)](#step-9-change-app-icon-optional)
 
 [**Step 5:** Notifications](#step-5-notifications)
 
+[**Step 6:** Bluetooth](#step-6-bluetooth)
+
+[**Step 7:** Connect Your Devices](#step-7-connect-your-devices)
+
+[**Step 8:** Enable Closed Loop](#step-8-enable-closed-loop)
+
+[**Step 9:** Change App Icon (Optional)](#step-9-change-app-icon-optional)
+
+
 </div>
 - - -
- 
+
+!!! tip "Need help finding these settings in your current DIY app?"
+    If you are coming from another Open Source Automated Insulin Dosing (OS-AID) app, these guides may help you with finding these settings in your previous app and inputing them into Trio.
+    
+    - [Trio 0.2.x](migration/trio-02x-migration.md)
+    - [iAPS](migration/iaps-migration.md)
+    - [Loop](migration/loop-migration.md)
+    - [AndroidAPS](migration/aaps-migration.md)
+
 ## **Step 1:** Prepare Trio
 
 In this step, you'll configure diagnostics sharing, optionally sync with Nightscout, and enter other essential setup information.
@@ -113,14 +122,6 @@ The next step is to enter your Therapy Settings. These include:
 - **Basal Rates**: Used as a baseline for increasing or decreasing insulin needs
 - **Carb Ratios**: How many grams of carbohydrate are countered by 1 unit of insulin
 - **Insulin Sensitivities**: How much 1 unit of insulin will lower your blood glucose
-
-!!! tip "Need help finding these settings in your current DIY app?"
-    If you are coming from another Open Source Automated Insulin Dosing (OS-AID) app, these guides may help you with finding these settings in your previous app and inputing them into Trio.
-    
-    - [Trio 0.2.x](migration/trio-02x-migration.md)
-    - [iAPS](migration/iaps-migration.md)
-    - [Loop](migration/loop-migration.md)
-    - [AndroidAPS](migration/aaps-migration.md)
     
 <div class="grid" markdown>
 
@@ -243,9 +244,9 @@ To configure the algorithm, you'll define the settings for Autosens, Super Micro
     This setting limits the size of a single unannounced meal SMB dose, aka UAM.  
     [Learn more about Max UAM Basal Minutes here](settings/algorithm/smb-settings.md#max-uam-basal-minutes).  
 
-    **Step 8: Set Max Delta-BG Threshold SMB**  
+    **Step 8: Set Max Allowed Glucose Rise for SMB**  
     This setting disables SMBs if the last two glucose values differ by more than this percent.  
-    [Learn more about Max Delta-BG Threshold SMB here](settings/algorithm/smb-settings.md#max-delta-bg-threshold-smb).
+    [Learn more about Max Allowed Glucose Rise for SMB here](settings/algorithm/smb-settings.md#max-allowed-glucose-rise-for-smb).
     
     ### Target Behavior
     [Target Behavior](settings/algorithm/target-behavior.md) allows you to adjust how temporary targets influence ISF, basal, and auto-targeting based on sensitivity or resistance.  

--- a/docs/configuration/settings/algorithm/smb-settings.md
+++ b/docs/configuration/settings/algorithm/smb-settings.md
@@ -9,7 +9,7 @@
     - SMBs reduce blood sugar more quickly than temporary basal rates.
     - If you want to configure SMBs only to run in certain conditions, do not turn on 'Enable SMB Always'.
     - For a detailed look at when SMBs are used, see the chart in [Are SMBs Allowed?](#are-smbs-allowed) section. 
-    - For setup recommendations, see the [Start-Up Guide](http://diy-trio.org/start-up-guide).
+    - For help with setup, see the [New User Guide](https://docs.diy-trio.org/configuration/new-user-setup.md).
 
 - - -
 
@@ -176,8 +176,8 @@ $$
 
 - - -
 
-## Max Delta-BG Threshold SMB
-**Default:** _30%_  
+## Max Allowed Glucose Rise for SMB
+**Default:** _20%_  
 **Setting Limits:** _10%-40%_
 
 This safety limiter looks at the difference between your last two blood glucose readings. If the difference is above this percent, Trio suspects them to be incorrect and will suspend all SMB delivery accordingly (including UAM). You can adjust the amount of change that should be allowed before SMBs are delivered.  
@@ -191,10 +191,10 @@ This safety limiter looks at the difference between your last two blood glucose 
         \frac{Current\ Glucose - Previous\ Glucose}{Previous\ Glucose}
         $$
         
-        Compare to Max Delta-BG Threshold SMB
+        Compare to Max Allowed Glucose Rise for SMB
         
         $$
-        Delta\ Percentage \gt \ or\ = \ or\ \lt Max\ Delta-BG\ Threshold\ Setting
+        Delta\ Percentage \gt \ or\ = \ or\ \lt Max\ Allowed\ Glucose\ Rise\ for\ SMB\ Setting
         $$
         
         **No SMB**: $\gt$  
@@ -214,14 +214,14 @@ This safety limiter looks at the difference between your last two blood glucose 
         +0.28\ or\ +28\%
         $$
 
-        His delta, or change in glucose, is an increase of **_28%_**
+        His rise, or increase in glucose, is an increase of **_28%_**
 
         $$
         28\%\gt 20\% = No\ SMBs
         $$
     
     ??? success "Answer"
-        This change is larger than the threshold, so **no SMBs will be given**. Trio will administer needed insulin via temp basal adjustment.
+        This increase is larger than the threshold, so **no SMBs will be given**. Trio will administer needed insulin via temp basal adjustment.
 
 !!! tip
     

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -16,17 +16,26 @@ Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome
     
     A detailed look at Trio's user interface and features
 
-<!-- -   __[Temporary Targets ✏️](usage/temptarget.md)__
+-   __[Temporary Targets ✏️](usage/temptarget.md)__
 
     - - -
     
+    🚧 Documentation Under Construction 🚧  
     How and when to use Temporary Targets
 
--   __[Overrides](usage/overrides.md)__
+-   __[Overrides ✏️](usage/overrides.md)__
 
     - - -
-    
+
+    🚧 Documentation Under Construction 🚧   
     How and when to use Overrides
     
--->    
+-   __[Statistics ✏️](usage/statistics.md)__
+
+    - - -
+
+    🚧 Documentation Under Construction 🚧      
+    A detailed look at Trio's Statistics interface
+    
+   
 </div>

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -16,21 +16,21 @@ Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome
     
     A detailed look at Trio's user interface and features
 
--   __[Temporary Targets ✏️](usage/temptarget.md)__
+-   __[Temporary Targets ✏️](temptarget.md)__
 
     - - -
     
     🚧 Documentation Under Construction 🚧  
     How and when to use Temporary Targets
 
--   __[Overrides ✏️](usage/overrides.md)__
+-   __[Overrides ✏️](overrides.md)__
 
     - - -
 
     🚧 Documentation Under Construction 🚧   
     How and when to use Overrides
     
--   __[Statistics ✏️](usage/statistics.md)__
+-   __[Statistics ✏️](statistics.md)__
 
     - - -
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,13 +190,14 @@ not_in_nav: |
   0.2.x/settings/configuration/preferences/statistics.md
   0.2.x/settings/devices/pump.md
   configuration/CompatibleDevices.md
+  configuration/migration/trio-02x-migration.md
+  configuration/migration/iaps-migration.md
+  configuration/migration/loop-migration.md
+  configuration/migration/aaps-migration.md
   configuration/transition-qa.md
   install/customize.md
   resources/citations.md
-  usage/overrides.md
-  usage/statistics.md
-  usage/temptarget.md
-
+  
 # Navigation (Page tree)
 nav:
   - index.md
@@ -209,8 +210,9 @@ nav:
   - Usage:
       - usage/index.md
       - User Interface: usage/interface.md
-      #- Temporary Targets ✏️: usage/temptarget.md
-      #- Overrides ✏️: usage/overrides.md
+      - Temporary Targets ✏️: usage/temptarget.md
+      - Overrides ✏️: usage/overrides.md
+      - Statistics ✏️: usage/statistics.md
   - Installation and Update:
       - install/index.md
       - Requirements:
@@ -295,6 +297,12 @@ nav:
               - Tidepool ✏️: configuration/settings/services/tidepool.md
               - Apple Health ✏️: configuration/settings/services/apple-health.md
           - Closing The Loop: configuration/settings/closed-loop.md
+      - Migration from other OS-AID Systems:
+          - configuration/migration/index.md
+          - Trio 0.2.x ✏️: configuration/migration/trio-02x-migration.md
+          - iAPS: configuration/migration/iaps-migration.md
+          - Loop ✏️: configuration/migration/loop-migration.md
+          - AndroidAPS ✏️: configuration/migration/aaps-migration.md
   - Help:
       - help/index.md
       - FAQs ✏️: help/faq.md


### PR DESCRIPTION
Creates a page dedicated to assisting with locating and identifying settings entered during onboarding when a user is migrating from iAPS as requested by HCPs.

Also adds files to create similar charts for Loop, Trio 0.2, and AAPS. 