### PR TITLE
⚰️ Remove "Build Select Script" page

### DIFF
--- a/docs/install/build/mac/build-select-script.md
+++ b/docs/install/build/mac/build-select-script.md
@@ -1,3 +1,0 @@
-# Build Select Script ✏️
-<!-- TODO -->
-<!-- TODO -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -227,7 +227,6 @@ nav:
           - Prepare your Computer: install/build/mac/computer.md
           - Prepare your iPhone: install/build/mac/iphone.md
           - Set Up Xcode: install/build/mac/xcode-setup.md
-          - Build Select Script ✏️: install/build/mac/build-select-script.md
           - Build Trio with Xcode: install/build/mac/build.md
           - Build Errors: install/build/mac/build-errors.md
           - Update Trio with Xcode: install/build/mac/update.md


### PR DESCRIPTION
This PR removes the empty **`Build Select Script Page`** as suggested on [Slack](https://loopandlearneditors.slack.com/archives/C071VLH3PE0/p1746631474012649) from both the filesystem and the Table of Contents.
