### PR TITLE
✏️ Fix broken equations (when they contain a glossary term)

### DIFF
--- a/docs/0.2.x/settings/configuration/concepts/autosens-dynamic.md
+++ b/docs/0.2.x/settings/configuration/concepts/autosens-dynamic.md
@@ -37,7 +37,7 @@ Dynamic ISF takes into consideration a new variable called the `Adjustment Facto
 Autosens determines a ratio (`autosens.ratio`) and alters your ISF in the following manner:
 
 $$
-Profile\ ISF\ ÷\ autosens.ratio\ =\ New\ ISF
+Profile\ \mathit{IS}\mathit{F}\ ÷\ autosens.ratio\ =\ New\ \mathit{IS}\mathit{F}
 $$
 
 !!! example
@@ -59,11 +59,11 @@ _Bill now temporarily has an ISF of 2.73 mmol/L/U (49 mg/dL/U)._
 Dynamic ISF (using the default logarithmic algorithm in Trio) uses an alternative formula to calculate the autosens.ratio for ISF adjustments. **Note this formula uses mg/dL and not mmol/L:**
 
 $$
-autosens.ratio\ =\ profile.sens\ *\ AF\ *\ TDD\ *\ log((BG/peak)+1)\ /\ 1800
+autosens.ratio\ =\ profile.sens\ *\ \mathit{A}\mathit{F}\ *\ \mathit{TD}\mathit{D}\ *\ log((\mathit{B}\mathit{G}/peak)+1)\ /\ 1800
 $$
 
 $$
-New ISF\ =\ (profile\ ISF)\ /\ (autosens.ratio)
+New \mathit{IS}\mathit{F}\ =\ (profile\ \mathit{IS}\mathit{F})\ /\ (autosens.ratio)
 $$
 
 _This formula considers your profile ISF (profile.sens in mg/dL), current blood glucose (BG in mg/dL), total daily dose (TDD over the last 24 hours), insulin peak effect (peak activity normally is 120 min) and a new variable called adjustment factor (AF) that allows for user tuning of Dynamic ISF/CR._
@@ -76,11 +76,11 @@ _This formula considers your profile ISF (profile.sens in mg/dL), current blood 
 This experimental feature alters the carb ratio (CR) based on current blood sugar and total daily dose (TDD). Unlike ISF, CR was not originally altered by autosens with respect to your detected sensitivity. Using Dynamic CR will lead to a dramatic change in how CR is calculated by Trio. Dynamic CR uses a similar formula as Dynamic ISF as described above:
 
 $$
-autosens.ratio\ =\ profile.sens\ *\ AF\ *\ TDD\ *\ log((BG/peak)+1)\ /\ 1800
+autosens.ratio\ =\ profile.sens\ *\ \mathit{A}\mathit{F}\ *\ \mathit{TD}\mathit{D}\ *\ log((\mathit{B}\mathit{G}/peak)+1)\ /\ 1800
 $$
 
 $$
-New\ CR\ =\ (profile\ CR)\ /\ (autosens.ratio)
+New\ \mathit{C}\mathit{R}\ =\ (profile\ \mathit{C}\mathit{R})\ /\ (autosens.ratio)
 $$
 
 If your CR changes dramatically daily and Trio is not providing adequate bolus recommendations, you can test this feature. Note that Trio already makes modifications to your recommended boluses without this feature enabled based on your blood glucose target, COB, and IOB.
@@ -114,7 +114,7 @@ See `Weighted Average of TDD` setting to understand how this variable is calcula
     Bill's TDD has been 55 U over the last 24 hours, and his 10-day average is 48 U. He has set his `Weighted average of TDD` in preferences to 0.7. His current profile basal rate is 1 U/h.
     
     $$  
-    Weighted\ average\ of\ TDD\ =\ 0.7 * 55 U + 0.3 * 48 U = 52.9 U
+    Weighted\ average\ of\ \mathit{TD}\mathit{D}\ =\ 0.7 * 55 U + 0.3 * 48 U = 52.9 U
     $$
     
     $$


### PR DESCRIPTION
This PR fixes equations broken in the 0.2.x "[Dynamic Settings](https://docs.diy-trio.org/0.2.x/settings/configuration/concepts/autosens-dynamic/#advanced-information)" page.  
These equations contain glossary terms.  
The glossary preprocessor messes them up. 

Fixes #118