### PR TITLE
Match settings to latest trio version

### DIFF
--- a/docs/configuration/new-user-setup.md
+++ b/docs/configuration/new-user-setup.md
@@ -209,67 +209,72 @@ To configure the algorithm, you'll define the settings for Autosens, Super Micro
     ### Autosens
     Autosensitivity, or [Autosens](settings/algorithm/autosens.md), adjusts insulin delivery based on observed sensitivity or resistance.
     
-    **Step 1: Set Autosens Min**  
+    **Step 1: Set [Autosens Min](settings/algorithm/autosens.md#autosens-min)**  
     This is the lower limit of the Autosens Ratio.  
-    [Learn more about Autosens Min](settings/algorithm/autosens.md#autosens-min).  
     
-    **Step 2: Set Autosens Max**  
+    **Step 2: Set [Autosens Max](settings/algorithm/autosens.md#autosens-max)**  
     This is the upper limit of the Autosens Ratio.  
-    [Learn more about Autosens Max](settings/algorithm/autosens.md#autosens-max).  
     
-    ### Super Micro Bolus (SMB)
-    [SMB (Super Micro Bolus)](settings/algorithm/smb-settings.md) is an oref algorithm feature that delivers small, frequent boluses instead of temporary basal adjustments, creating a more responsive system.
+    ### [Super Micro Bolus (SMB)](settings/algorithm/smb-settings.md)
+    SMB (Super Micro Bolus) is an oref algorithm feature that delivers small, frequent boluses instead of temporary basal adjustments, creating a more responsive system. The onboarding options are different depending on what you choose for Step 3.
     
-    **Step 3: Enable/Disable SMB Always**  
-    If you do not want to always allow SMBs, and would rather be more selective with the SMBs you enable, keep `Enable SMB Always` ***OFF*** and follow the SMB documentation below to select other SMB options _after_ you've completed the Onboarding Wizard.  
-    [Learn more about SMBs](settings/algorithm/smb-settings.md).
+    **Step 3: [Enable/Disable SMB Always](settings/algorithm/smb-settings.md#enable-smb-always)**
     
-    **Step 4: Allow SMB with High Temp Target**  
+    === "Enable SMB Always"  
+        When this setting is enabled, Super Micro Boluses (SMBs) will always be allowed if dosing calculations determine insulin is needed via the SMB delivery method. The exception is when a high temp target is set. Enabling SMB Always will skip the other individual SMB options during the onboarding process.
+    
+    === "Disable SMB Always"
+        If you do not want to always allow SMBs, and would rather be more selective with the SMBs you enable, keep `Enable SMB Always` ***OFF*** and the individual SMB options will appear next.  
+    
+        **Step 3a: [Enable/Disable SMB with COB](settings/algorithm/smb-settings.md#enable-smb-with-cob)**  
+        Enabling this feature allows Trio to administer SMBs when there are carbs on board (COB).  
+    
+        **Step 3b: [Enable SMB with TempTarget](settings/algorithm/smb-settings.md#enable-smb-with-temptarget)**  
+        Enabling this feature allows Trio to deliver insulin required using SMBs at times in which a manual temporary target (temp target) under **100 mg/dL (5.5 mmol/L)** is set.  
+    
+        **Step 3c: [Enable SMB After Carbs](settings/algorithm/smb-settings.md#enable-smb-after-carbs)**  
+        Enabling this feature allows Trio to deliver insulin required using SMBs for **6 hours** after any carb entry, regardless of whether there are active carbs on board (COB).  
+        
+        **Step 3d: [Enable SMB with High Glucose](settings/algorithm/smb-settings.md#enable-smb-with-high-glucose)**  
+        Enabling this feature allows Trio to deliver insulin required using SMBs when your glucose reading is above the value set as your [High Glucose Target](settings/algorithm/smb-settings/#high-glucose-target). This additional setting will appear when you enable this feature.  
+    
+    **Step 4: [Allow SMB with High Temp Target](settings/algorithm/smb-settings.md#allow-smb-with-high-temptarget)**  
     This is the only setting not enabled when `Enable SMB Always` is turned on. Turning this setting on will allow SMBs when a manual Temp Target is set greater than 100 mg/dL (5.5 mmol/L). 
     !!! warning
         This type of Temp Target is often set as a low recovery step. If you set a high temp target when recovering from a low to avoid over treatment during recovery, it is advised to keep this setting _OFF_.
         
-    **Step 5: Enable UAM**  
+    **Step 5: [Enable UAM](settings/algorithm/smb-settings.md#enable-uam)**  
     Best practice is to have both UAM and SMBs enabled at the same time. If you have enabled SMB Always (or plan to enable individual SMBs as soon as you complete onboarding), it is advised to turn `Enable UAM` ***ON*** during this step.  
-    [Learn more about UAM](settings/algorithm/smb-settings.md#enable-uam).  
     
     !!! tip
         The settings in Steps 6, 7, and 8 are often misunderstood. Follow the links to understand what they do more clearly.
     
-    **Step 6: Set Max SMB Basal Minutes**  
+    **Step 6: Set [Max SMB Basal Minutes](settings/algorithm/smb-settings.md#max-smb-basal-minutes)**  
     This setting limits the size of a single SMB dose.  
-    [Learn more about Max SMB Basal Minutes here](settings/algorithm/smb-settings.md#max-smb-basal-minutes).  
     
-    **Step 7: Set Max UAM Basal Minutes**  
+    **Step 7: Set [Max UAM Basal Minutes](settings/algorithm/smb-settings.md#max-uam-basal-minutes)**  
     This setting limits the size of a single unannounced meal SMB dose, aka UAM.  
-    [Learn more about Max UAM Basal Minutes here](settings/algorithm/smb-settings.md#max-uam-basal-minutes).  
 
-    **Step 8: Set Max Allowed Glucose Rise for SMB**  
+    **Step 8: Set [Max Allowed Glucose Rise for SMB](settings/algorithm/smb-settings.md#max-allowed-glucose-rise-for-smb)**  
     This setting disables SMBs if the last two glucose values differ by more than this percent.  
-    [Learn more about Max Allowed Glucose Rise for SMB here](settings/algorithm/smb-settings.md#max-allowed-glucose-rise-for-smb).
     
     ### Target Behavior
     [Target Behavior](settings/algorithm/target-behavior.md) allows you to adjust how temporary targets influence ISF, basal, and auto-targeting based on sensitivity or resistance.  
     
-    **Step 9: High Temp Target Raises Sensitivity**  
+    **Step 9: [High Temp Target Raises Sensitivity](settings/algorithm/target-behavior.md#high-temp-target-raises-sensitivity)**  
     This setting increases sensitivity when glucose is above target if a manual Temp Target > 100mg/dL (5.5mmol/L) is set.  
-    [Learn more about High Temp Target Raises Sensitivity here](settings/algorithm/target-behavior.md#high-temp-target-raises-sensitivity).  
     
-    **Step 10: Low Temp Target Lowers Sensitivity**  
+    **Step 10: [Low Temp Target Lowers Sensitivity](settings/algorithm/target-behavior.md#low-temp-target-lowers-sensitivity)**  
     This setting decreases sensitivity when glucose is below target if a manual Temp Target < 100mg/dL (5.5mmol/L) is set.  
-    [Learn more about Low Temp Target Lowers Sensitivity here](settings/algorithm/target-behavior.md#low-temp-target-lowers-sensitivity).  
     
-    **Step 11: Sensitivity Raises Target**  
+    **Step 11: [Sensitivity Raises Target](settings/algorithm/target-behavior.md#sensitivity-raises-target)**  
     This setting raises the glucose target if the Sensitivity Ratio is > 1.0.  
-    [Learn more about Sensitivity Raises Target here](settings/algorithm/target-behavior.md#sensitivity-raises-target).  
 
-    **Step 12: Resistance Lowers Target**  
+    **Step 12: [Resistance Lowers Target](settings/algorithm/target-behavior.md#resistance-lowers-target)**  
     This setting lowers the glucose target if the Sensitivity Ratio is < 1.0.  
-    [Learn more about Resistance Lowers Target here](settings/algorithm/target-behavior.md#resistance-lowers-target).  
     
-    **Step 13: Half Basal Exercise Target**
+    **Step 13: [Half Basal Exercise Target](settings/algorithm/target-behavior.md#half-basal-exercise-target)**
     This setting scales your basal rate such that your basal will be set to 50% at this value. This setting is only applied when `High Temp Target Raises Sensitivity` and/or `Low Temp Target Lowers Sensitivity` are enabled.  
-    [Learn more about Half Basal Exercise Target here](settings/algorithm/target-behavior.md#half-basal-exercise-target).  
 
 === "After Onboarding"
     
@@ -299,13 +304,13 @@ To configure the algorithm, you'll define the settings for Autosens, Super Micro
         - [Enable SMB with COB](settings/algorithm/smb-settings.md#enable-smb-with-cob)
         - [Enable SMB with TempTarget](settings/algorithm/smb-settings.md#enable-smb-with-temptarget)
         - [Enable SMB After Carbs](settings/algorithm/smb-settings.md#enable-smb-after-carbs)
-        - [Enable SMB with High BG](settings/algorithm/smb-settings.md#enable-smb-with-high-bg)
+        - [Enable SMB with High Glucose](settings/algorithm/smb-settings.md#enable-smb-with-high-glucose)
         - [Allow SMB with High Temp Target](settings/algorithm/smb-settings.md#allow-smb-with-high-temptarget)
     - [Enable UAM](settings/algorithm/smb-settings.md#enable-uam)  
     - SMB Limiting Settings
         - [Max SMB Basal Minutes](settings/algorithm/smb-settings.md#max-smb-basal-minutes)
         - [Max UAM Basal Minutes](settings/algorithm/smb-settings.md#max-uam-basal-minutes)
-        - [Max Delta-BG Threshold SMB](settings/algorithm/smb-settings.md#max-delta-bg-threshold-smb)
+        - [Max Allowed Glucose Rise for SMB](settings/algorithm/smb-settings.md#max-allowed-glucose-rise-for-smb)
     
     ### Edit Target Behavior
     [Target Behavior](settings/algorithm/target-behavior.md) allows you to adjust how temporary targets influence ISF, basal, and auto-targeting based on sensitivity or resistance.

--- a/docs/configuration/settings/algorithm/autosens.md
+++ b/docs/configuration/settings/algorithm/autosens.md
@@ -7,7 +7,14 @@
     - Autosens Max/Min limits sensitivity adjustments
 
 ## Sensitivity Ratio
-The Sensitivity Ratio (previously `Autosens Ratio`) is used to calculate the amount of adjustment needed to your basal rates and ISF. If Dynamic CR is enabled, it will also apply to your carb ratio.    
+The Sensitivity Ratio (previously `Autosens Ratio`) is used to calculate the amount of adjustment needed to your basal rates and ISF. If Dynamic CR is enabled, it will also apply to your carb ratio.  
+
+!!! tip
+    This previously was shown as a decimal value as `Autosens Ratio` and is now shown as a percentage as `Sensitivity Ratio`.
+    
+    If your Sensitivity Ratio is showing 120%, this means Trio has calculated that your insulin needs are 120% of your standard needs.
+    
+    If your Senstivitity Ratio is 100%, Trio is using your entered Therapy Settings without any adjustments.
 
 There are 3 options for you to select from for how your Sensitivity Ratio is calculated:
     
@@ -48,7 +55,7 @@ $$
 \frac{ProfileISF}{Sensitivity\ Ratio} = Calculated\ Sensitivity
 $$
 
-??? question "Bill has a Profile ISF of 54 mg/dL/U (3 mmol/L/U). Trio detects Bill has been more resistant to insulin lately and needs to increase his insulin. It calculates Bill has a [Sensitivity Ratio](#sensitivity-ratio) of 1.1 using Autosens. What Calculated Sensitivity, aka temporary ISF, will Trio use for this loop cycle?"
+??? question "Bill has a Profile ISF of 54 mg/dL/U (3 mmol/L/U). Trio detects Bill has been more resistant to insulin lately and needs to increase his insulin. It calculates Bill has a [Sensitivity Ratio](#sensitivity-ratio) of 110% using Autosens. What Calculated Sensitivity, aka temporary ISF, will Trio use for this loop cycle?"
     
     ??? info "Here is the formula used for Calculated Sensitivity:"
     
@@ -59,7 +66,7 @@ $$
     ??? note "Calculate the temporary ISF, Calculated Sensitivity, used in this loop cycle:"
         
         $$
-        \frac{54\ mg/dL/U}{1.1} =
+        \frac{54\ mg/dL/U}{110\%} =
         $$
         
         $$
@@ -96,7 +103,7 @@ Autosens Min sets the minimum Sensitivity Ratio used by Autosens, Logarithmic Dy
 - - -
 
 ## Rewind Resets Autosens
-**Default:** *OFF*  
+**Default:** *ON*  
 **_This setting applies to Medtronic Users only_**
 
 This feature resets the Sensitivity Ratio to neutral when you rewind your pump on the assumption that this corresponds to a site change.

--- a/docs/configuration/settings/algorithm/smb-settings.md
+++ b/docs/configuration/settings/algorithm/smb-settings.md
@@ -58,11 +58,11 @@ Enabling this feature allows Trio to deliver insulin required using SMBs for **6
 
 - - -
 
-## Enable SMB with High BG
+## Enable SMB with High Glucose
 **Default:** _OFF_  
-Enabling this feature allows Trio to deliver insulin required using SMBs when your glucose reading is above the value set as your 'High BG Target'. This additional setting will appear when you enable this feature.  
+Enabling this feature allows Trio to deliver insulin required using SMBs when your glucose reading is above the value set as your 'High Glucose Target'. This additional setting will appear when you enable this feature.  
 
-### High BG Target
+### High Glucose Target
 **Default:** _110 mg/dL_ | _6.1 mmol/L_  
 If 'Enable SMB with High BG' is enabled, SMBs will be allowed if your glucose is above this value.  
 
@@ -185,7 +185,7 @@ This safety limiter looks at the difference between your last two blood glucose 
 ??? question "Bill's last CGM reading was 90 mg/dL. The very next reading is 115 mg/dL. Will Bill receive the insulin needed as an SMB?"
     
     ??? info "Here are the formulas you'll need:"
-        Delta Percentage:
+        Rise Percentage:
         
         $$
         \frac{Current\ Glucose - Previous\ Glucose}{Previous\ Glucose}
@@ -194,7 +194,7 @@ This safety limiter looks at the difference between your last two blood glucose 
         Compare to Max Allowed Glucose Rise for SMB
         
         $$
-        Delta\ Percentage \gt \ or\ = \ or\ \lt Max\ Allowed\ Glucose\ Rise\ for\ SMB\ Setting
+        Rise\ Percentage \gt \ or\ = \ or\ \lt Max\ Allowed\ Glucose\ Rise\ for\ SMB\ Setting
         $$
         
         **No SMB**: $\gt$  

--- a/docs/configuration/settings/algorithm/smb-settings.md
+++ b/docs/configuration/settings/algorithm/smb-settings.md
@@ -115,7 +115,7 @@ If any of the SMB options are enabled, this limit will apply to all SMBs except 
 To calculate the maximum SMB allowed based on this setting, use the following formula:  
 
 $$
-\frac{Max\ SMB\ Basal\ Minutes}{60} \times Current\ Basal\ Rate
+\frac{Max\ \mathit{SM}\mathit{B}\ Basal\ Minutes}{60} \times Current\ Basal\ Rate
 $$
 
 ??? question "Bill's current basal rate is 2.0 units/hr. His `Max SMB Basal Minutes` is set to 30 minutes. What is the largest SMB he can receive?"
@@ -123,7 +123,7 @@ $$
     ??? info "Here is the formula you will need:"
     
         $$
-        \frac{Max\ SMB\ Basal\ Minutes}{60} \times Current\ Basal\ Rate
+        \frac{Max\ \mathit{SM}\mathit{B}\ Basal\ Minutes}{60} \times Current\ Basal\ Rate
         $$
         
     ??? note "Calculate Bill's largest SMB:"
@@ -194,7 +194,7 @@ This safety limiter looks at the difference between your last two blood glucose 
         Compare to Max Allowed Glucose Rise for SMB
         
         $$
-        Rise\ Percentage \gt \ or\ = \ or\ \lt Max\ Allowed\ Glucose\ Rise\ for\ SMB\ Setting
+        Rise\ Percentage \gt \ or\ = \ or\ \lt Max\ Allowed\ Glucose\ Rise\ for\ \mathit{SM}\mathit{B}\ Setting
         $$
         
         **No SMB**: $\gt$  
@@ -217,7 +217,7 @@ This safety limiter looks at the difference between your last two blood glucose 
         His rise, or increase in glucose, is an increase of **_28%_**
 
         $$
-        28\%\gt 20\% = No\ SMBs
+        28\%\gt 20\% = No\ \mathit{SM}\mathit{B}s
         $$
     
     ??? success "Answer"

--- a/docs/configuration/settings/closed-loop.md
+++ b/docs/configuration/settings/closed-loop.md
@@ -18,8 +18,8 @@ Many users feel the need to stay in open loop initially for a variety of reasons
 <div class="grid cards" markdown>
     
 -   - Set [Max IOB](therapy/units-limits.md#max-iob) to **0**
-    - Set [Autosens Max](algorithm/autosens.md#autosens-max) to **1**
-    - Set [Autosens Min](algorithm/autosens.md#autosens-min) to **1**
+    - Set [Autosens Max](algorithm/autosens.md#autosens-max) to **100%**
+    - Set [Autosens Min](algorithm/autosens.md#autosens-min) to **100%**
     - All other [Algorithm Settings](algorithm/index.md) should remain at their defaults if you are a new user
 
 -   !!! tip "Existing Users"

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@
     - New educational videos are coming soon.
 
 # What is Trio?
+!!! note
+    The video refers to Trio 1.0, which will not be the official version number until beta testing is complete and it is released to the main branch.
 
 <video controls  preload="metadata">
   <source src="assets/videos/trio-intro.mp4" type="video/mp4">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -299,10 +299,10 @@ nav:
           - Closing The Loop: configuration/settings/closed-loop.md
       - Migration from other OS-AID Systems:
           - configuration/migration/index.md
-          - Trio 0.2.x ✏️: configuration/migration/trio-02x-migration.md
-          - iAPS: configuration/migration/iaps-migration.md
-          - Loop ✏️: configuration/migration/loop-migration.md
-          - AndroidAPS ✏️: configuration/migration/aaps-migration.md
+          - Migration from Trio 0.2.x ✏️: configuration/migration/trio-02x-migration.md
+          - Migration from iAPS: configuration/migration/iaps-migration.md
+          - Migration from Loop ✏️: configuration/migration/loop-migration.md
+          - Migration from AndroidAPS ✏️: configuration/migration/aaps-migration.md
   - Help:
       - help/index.md
       - FAQs ✏️: help/faq.md


### PR DESCRIPTION
closed-loop.md
- fix autosens max and autosens min from decimal value to percentage value

autosens.md
- clarify the change from autosens ratio to sensitivity ratio and explain shift from decimal to percentage
- update math in Bill examples

smb-settings.md
- update settings names to match app updates

new-user-setup.md
- fix broken links
- update location of links in settings names to simplify and reduce amount of text
- add missing individual SMB options when SMB Always is disabled during onboarding

index.md
- add clarifying statement about the video referencing "Trio 1.0"

mkdocs.yml
- updates the yml file so that when a PDF is initiated in the migration section, it states "Migration From ..." rather than just the previous app name, which could be confusing for a user printing the PDF. 