### PR TITLE
Update desmos graphs

### DIFF
--- a/docs/configuration/settings/algorithm/dynamic-settings.md
+++ b/docs/configuration/settings/algorithm/dynamic-settings.md
@@ -244,16 +244,16 @@ See [Weighted Average of TDD](#weighted-average-of-tdd) setting to understand ho
 
 ## Logarithmic Desmos Graphs
 
-[Click here to view a graph depicting the logarithmic formula in mg/dL](https://www.desmos.com/calculator/zrkugmdnob)
+[Click here to view a graph depicting the logarithmic formula in mg/dL](https://www.desmos.com/calculator/ousohtexbk)
 
-[Click here to view a graph depicting the logarithmic formula in mmol/L](https://www.desmos.com/calculator/aoxzzrhpro)
+[Click here to view a graph depicting the logarithmic formula in mmol/L](https://www.desmos.com/calculator/q3hzvylki3)
 
 - - -
 
 ## Sigmoid Desmos Graphs
 
-[Click here to view a graph depicting the sigmoid formula in mg/dL](https://www.desmos.com/calculator/s9jxdmqhh8)
+[Click here to view a graph depicting the sigmoid formula in mg/dL](https://www.desmos.com/calculator/eyf32mtgxo)
 
-[Click here to view a graph depicting the sigmoid formula in mmol/L](https://www.desmos.com/calculator/nb5l47yx0h)
+[Click here to view a graph depicting the sigmoid formula in mmol/L](https://www.desmos.com/calculator/2vvtudm20p)
 
 - - -


### PR DESCRIPTION
This updates to Desmos graphs to match the new Trio settings. For example, it uses `120%` instead of just `1.2`. 

To note: Desmos graphs get a new URL any time you change anything.