### PR TITLE
TrioDocs Domain Migration to `triodocs.org` from `diy‑trio.org` - Part 1

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-docs.diy-trio.org
+triodocs.org


### PR DESCRIPTION
This PR modifies the configuration files and the pages that refer to the previous domain by changing `diy-trio.org` to `triodocs.org`.

Refer to the associated issue: #124.