### PR TITLE
TrioDocs Domain Migration to `triodocs.org` from `diy‑trio.org`  - Part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Repository for [Trio documentation (under development)](https://docs.diy-trio.org)
+Repository for [Trio documentation (under development)](https://triodocs.org)
 
 ## Install
 

--- a/docs/0.2.x/Getting-Started/Overview.md
+++ b/docs/0.2.x/Getting-Started/Overview.md
@@ -23,8 +23,6 @@ If you require help defining and determining those settings, please seek assista
 
 To use Trio, you are required to build the application from the source code. This does not require substantial technical know-how but is a time-consuming process. You may need to carry this out through several sessions on your first attempt.
 
-Upon installation, you will need to configure your settings appropriately. For step-by-step instructions on using the app, follow the [start-up guide](http://diy-trio.org/start-up-guide). 
-
 **Ready to Get Started?**
 Head to the [New User Guide](../Setup/New-User-Setup.md) to get started!
 

--- a/docs/0.2.x/resources/translate.md
+++ b/docs/0.2.x/resources/translate.md
@@ -5,57 +5,57 @@
 Click on a language on the links below to turn on Google's automatic translation.
 
 
-[عربي](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ar)
+[عربي](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ar)
 
-[Български](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=bg)
+[Български](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=bg)
 
-[Čeština](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=cs)
+[Čeština](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=cs)
 
-[Deutsch](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=de)
+[Deutsch](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=de)
 
-[Dansk](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=da)
+[Dansk](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=da)
 
-[Ελληνικά](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=el)
+[Ελληνικά](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=el)
 
-[Español](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=es)
+[Español](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=es)
 
-[日本](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ja)
+[日本](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ja)
 
-[Suomi](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fi)
+[Suomi](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fi)
 
-[Français](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fr)
+[Français](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fr)
 
-[עברית](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=iw)
+[עברית](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=iw)
 
-[Hrvatski](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hr)
+[Hrvatski](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hr)
 
-[हिंदी](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi)
+[हिंदी](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi)
 
-[Italiano](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=it)
+[Italiano](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=it)
 
-[한국어](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ko)
+[한국어](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ko)
 
-[Norsk](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=no)
+[Norsk](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=no)
 
-[Nederlands](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=nl)
+[Nederlands](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=nl)
 
-[Polski](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pl)
+[Polski](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pl)
 
-[Português](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pt)
+[Português](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pt)
 
-[Română](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ro)
+[Română](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ro)
 
-[Русский](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ru)
+[Русский](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ru)
 
-[Slovenčina](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sk)
+[Slovenčina](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sk)
 
-[Svenska](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sv)
+[Svenska](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sv)
 
-[Turkish](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=tr)
+[Turkish](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=tr)
 
-中文（[简体](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-CN))
+中文（[简体](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-CN))
 
-中文（[繁體](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-TW))
+中文（[繁體](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-TW))
 
 
 ## Change Language
@@ -63,16 +63,16 @@ Click on a language on the links below to turn on Google's automatic translation
 To modify the language choice for the whole site, copy the line below, paste it into the URL, and then choose the desired language from the list above.
 
 ```
-https://docs.diy-trio.org/resources/translate.html
+https://triodocs.org/0.2.x/resources/translate
 ```
 
 **OR**
 
-Use the Google Translation three-dot menu (`⠇`) and select `Go to original URL ↗` while on the Translation page.
+Use the Google Translate three-dot menu (`⠇`) and select `Go to original URL ↗` while on the Translation page.
 
 ## More Information
 
-- Every website page gets automatically translated to the selected language as do links to other websites
+- Every website page gets automatically translated to the selected language, as do links to other websites
 
 - The Google Translate Tool will appear at the top of each page
   - Trio Docs how-to: [Google Translate Tool Instructions](#google-translate-tool-instructions)

--- a/docs/0.2.x/settings/configuration/preferences/smbsettings.md
+++ b/docs/0.2.x/settings/configuration/preferences/smbsettings.md
@@ -6,7 +6,6 @@
     - If you want Trio to make all SMB decisions, select Enable SMB Always and leave the other settings deselected.
        - Follow the directions below if you want to configure SMBs only to run in certain conditions.
     - For a detailed look at when SMBs are delivered, see the chart in [Are SMBs Allowed?](#are-smbs-allowed) section. 
-    - For setup recommendations, see the [Start-Up Guide](http://diy-trio.org/start-up-guide).
 
 ## Enable SMB Always
 Enabling this setting allows SMBs to be delivered if your blood sugar is predicted to go above target. 

--- a/docs/assets/templates/covers/front.html.j2
+++ b/docs/assets/templates/covers/front.html.j2
@@ -88,7 +88,7 @@
       <br />
       Date: {{ build_date }}
       <p>
-        Download the latest version on: https://docs.diy-trio.org
+        Download the latest version on: https://triodocs.org
       </p>
     </div>
     <div class="title">{{ page.title }}</div>

--- a/docs/configuration/settings/algorithm/smb-settings.md
+++ b/docs/configuration/settings/algorithm/smb-settings.md
@@ -9,7 +9,7 @@
     - SMBs reduce blood sugar more quickly than temporary basal rates.
     - If you want to configure SMBs only to run in certain conditions, do not turn on 'Enable SMB Always'.
     - For a detailed look at when SMBs are used, see the chart in [Are SMBs Allowed?](#are-smbs-allowed) section. 
-    - For help with setup, see the [New User Guide](https://docs.diy-trio.org/configuration/new-user-setup.md).
+    - For help with setup, see the [New User Guide](../../new-user-setup.md).
 
 - - -
 

--- a/docs/help/translate.md
+++ b/docs/help/translate.md
@@ -5,57 +5,57 @@
 <!-- Click on a language on the links below to turn on Google's automatic translation.
 
 
-[عربي](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ar)
+[عربي](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ar)
 
-[Български](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=bg)
+[Български](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=bg)
 
-[Čeština](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=cs)
+[Čeština](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=cs)
 
-[Deutsch](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=de)
+[Deutsch](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=de)
 
-[Dansk](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=da)
+[Dansk](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=da)
 
-[Ελληνικά](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=el)
+[Ελληνικά](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=el)
 
-[Español](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=es)
+[Español](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=es)
 
-[日本](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ja)
+[日本](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ja)
 
-[Suomi](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fi)
+[Suomi](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fi)
 
-[Français](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fr)
+[Français](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=fr)
 
-[עברית](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=iw)
+[עברית](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=iw)
 
-[Hrvatski](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hr)
+[Hrvatski](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hr)
 
-[हिंदी](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi)
+[हिंदी](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi)
 
-[Italiano](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=it)
+[Italiano](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=it)
 
-[한국어](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ko)
+[한국어](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ko)
 
-[Norsk](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=no)
+[Norsk](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=no)
 
-[Nederlands](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=nl)
+[Nederlands](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=nl)
 
-[Polski](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pl)
+[Polski](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pl)
 
-[Português](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pt)
+[Português](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=pt)
 
-[Română](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ro)
+[Română](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ro)
 
-[Русский](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ru)
+[Русский](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=ru)
 
-[Slovenčina](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sk)
+[Slovenčina](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sk)
 
-[Svenska](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sv)
+[Svenska](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=sv)
 
-[Turkish](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=tr)
+[Turkish](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=tr)
 
-中文（[简体](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-CN))
+中文（[简体](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-CN))
 
-中文（[繁體](https://docs-diy--trio-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-TW))
+中文（[繁體](https://triodocs-org.translate.goog/?_x_tr_sl=auto&_x_tr_tl=zh-TW))
 
 
 ## Change Language
@@ -63,16 +63,16 @@
 To modify the language choice for the whole site, copy the line below, paste it into the URL, and then choose the desired language from the list above.
 
 ```
-https://docs.diy-trio.org/resources/translate.html
+https://triodocs.org/help/translate
 ```
 
 **OR**
 
-Use the Google Translation three-dot menu (`⠇`) and select `Go to original URL ↗` while on the Translation page.
+Use the Google Translate three-dot menu (`⠇`) and select `Go to original URL ↗` while on the Translation page.
 
 ## More Information
 
-- Every website page gets automatically translated to the selected language as do links to other websites
+- Every website page gets automatically translated to the selected language, as do links to other websites
 
 - The Google Translate Tool will appear at the top of each page
   - Trio Docs how-to: [Google Translate Tool Instructions](#google-translate-tool-instructions)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 # Project information
 site_name: TrioDocs
 site_description: Documentation of Trio, an Automated Insulin Delivery system for iOS.
-site_url: https://docs.diy-trio.org/
+site_url: https://triodocs.org/
 site_author: Trio Community
 use_directory_urls: !ENV [CHECK_BROKEN_LINKS, True]
 


### PR DESCRIPTION
This PR is a follow-up to PR #125, and it addresses the remaining files post `triodocs.org` domain migration:

- `docs/0.2.x/Getting-Started/Overview.md`
- `docs/0.2.x/resources/translate.md`
- `docs/0.2.x/settings/configuration/preferences/smbsettings.md`
- `docs/assets/templates/covers/front.html.j2`
- `docs/help/translate.md`
- `mkdocs.yml`
- `README.md`

This also:

- [Fixes the sitemap](https://github.com/nightscout/trio-docs/blob/5e82409a7bf3a519a969bfe4676f6da2f290df84/mkdocs.yml#L4), which now uses the new `triodocs.org` domain.
- Removes references to the Start-up Guide (http://diy-trio.org/start-up-guide) until we revive it with up-to-date content.
 