### PR TITLE
✏️ Fix TOC, PDF, broken links, unused files

### DIFF
--- a/docs/configuration/new-user-setup.md
+++ b/docs/configuration/new-user-setup.md
@@ -236,7 +236,7 @@ To configure the algorithm, you'll define the settings for Autosens, Super Micro
         Enabling this feature allows Trio to deliver insulin required using SMBs for **6 hours** after any carb entry, regardless of whether there are active carbs on board (COB).  
         
         **Step 3d: [Enable SMB with High Glucose](settings/algorithm/smb-settings.md#enable-smb-with-high-glucose)**  
-        Enabling this feature allows Trio to deliver insulin required using SMBs when your glucose reading is above the value set as your [High Glucose Target](settings/algorithm/smb-settings/#high-glucose-target). This additional setting will appear when you enable this feature.  
+        Enabling this feature allows Trio to deliver insulin required using SMBs when your glucose reading is above the value set as your [High Glucose Target](settings/algorithm/smb-settings.md#high-glucose-target). This additional setting will appear when you enable this feature.  
     
     **Step 4: [Allow SMB with High Temp Target](settings/algorithm/smb-settings.md#allow-smb-with-high-temptarget)**  
     This is the only setting not enabled when `Enable SMB Always` is turned on. Turning this setting on will allow SMBs when a manual Temp Target is set greater than 100 mg/dL (5.5 mmol/L). 

--- a/docs/configuration/settings/features/remote-control.md
+++ b/docs/configuration/settings/features/remote-control.md
@@ -254,7 +254,7 @@ If you are new to this topic, please refer to [LoopDocs: Remote Configuration](h
 * The same set of Nightscout config vars is used by Trio and Loop
     * Ignore references to LoopCaregiver in the LoopDocs link, you will use *LoopFollow* or the Nightscout `Careportal`
 * The Apple Push Notification (APNS) config vars must be configured for the *Apple* developer ID of the person who builds the Trio app (`LOOP_DEVELOPER_TEAM_ID` in the table below)
-* The first two values in this table are the same ones added to the *LoopFollow* app when configuring the [LoopFollow App: Remote Settings](#loopfollow-app-trio-remote-control)
+* The first two values in this table are the same ones added to the *LoopFollow* app when configuring the [LoopFollow App: Trio Remote Control](#loopfollow-app-trio-remote-control)
 
 | Build<br>Method | <div style="width:220px"></div> Config Var | Format of Config Var Value |
 |:-:|:--|:--|

--- a/docs/configuration/settings/features/remote-control.md
+++ b/docs/configuration/settings/features/remote-control.md
@@ -185,7 +185,7 @@ See [Nightscout for Temp Target Control](#nightscout-for-temp-target-control). T
 
 ### Guardrails
 
-The maximum allowed entries for Bolus, Carbs, Protein and Fat are configured in the guardrails section shown in the graphic below. This example is one in which the Shared Secret and APNS values have not yet been added.
+The maximum allowed entries for Bolus, Carbs, Protein, and Fat are configured in the guardrails section shown in the graphic below. This example is one in which the Shared Secret and APNS values have not yet been added.
 
 ![default guardrails](img/lf-trc-guardrails.jpg){width="500"}
 
@@ -218,7 +218,7 @@ Once the *LoopFollow* phone is configured, and while the Trio phone is handy, te
 
 Remember to give the system time to update.
 
-The sequence is *LoopFollow* to *Apple Push Notifications* to *Trio* which uploads to *Nightscout* and then is displayed in the *LoopFollow* main screen.
+The sequence is *LoopFollow* to *Apple Push Notifications* to *Trio*, which uploads to *Nightscout* and then is displayed in the *LoopFollow* main screen.
 
 ### Remote Meal
 
@@ -254,7 +254,7 @@ If you are new to this topic, please refer to [LoopDocs: Remote Configuration](h
 * The same set of Nightscout config vars is used by Trio and Loop
     * Ignore references to LoopCaregiver in the LoopDocs link, you will use *LoopFollow* or the Nightscout `Careportal`
 * The Apple Push Notification (APNS) config vars must be configured for the *Apple* developer ID of the person who builds the Trio app (`LOOP_DEVELOPER_TEAM_ID` in the table below)
-* The first two values in this table are the same ones added to the *LoopFollow* app when configuring the [LoopFollow App: Remote Settings](#loopfollow-app-remote-settings)
+* The first two values in this table are the same ones added to the *LoopFollow* app when configuring the [LoopFollow App: Remote Settings](#loopfollow-app-trio-remote-control)
 
 | Build<br>Method | <div style="width:220px"></div> Config Var | Format of Config Var Value |
 |:-:|:--|:--|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,7 +134,7 @@ extra:
     - icon: fontawesome/brands/facebook
       link: https://www.facebook.com/groups/diytrio
       name: Trio on Facebook
-  version: 0.2.1
+  version: 0.4.0
 
 watch:
   - includes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,10 +190,6 @@ not_in_nav: |
   0.2.x/settings/configuration/preferences/statistics.md
   0.2.x/settings/devices/pump.md
   configuration/CompatibleDevices.md
-  configuration/migration/trio-02x-migration.md
-  configuration/migration/iaps-migration.md
-  configuration/migration/loop-migration.md
-  configuration/migration/aaps-migration.md
   configuration/transition-qa.md
   install/customize.md
   resources/citations.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ plugins:
         - pdf.scss
         - primary_color.css
         - trio-docs.pdf
+        - trio-intro.mp4
   - search
 
 extra_css:


### PR DESCRIPTION
This PR:
 
- ✏️ Fixes several broken links and anchors.
- 🔧 Sets the correct Trio version in the PDF
- 🔧 Declare the Trio intro video as an unused file because the [mkdocs-unused-files](https://github.com/wilhelmer/mkdocs-unused-files) plugin incorrectly identifies it as unused since it does not properly handle files referenced in raw HTML tags. 
- 🔧 Removed the migration files from the `not_in_nav` section, as they are now included in the Table of Contents.