### PR TITLE
♻️ Reorder TOC Configuration/Trio Settings/Therapy

### DIFF
--- a/docs/configuration/settings/therapy/index.md
+++ b/docs/configuration/settings/therapy/index.md
@@ -16,17 +16,17 @@ Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome
     
     Set your preferred glucose units and main dosing limitations
 
+-   __[Glucose Targets](glucose-targets.md)__
+
+    - - -
+    
+    Step by step guide on setting your glucose target(s)
+    
 -   __![Trio Logo](../../../assets/images/trio-logo.png){ width="20" }[Basal Rates](basal-rates.md)__
 
     - - -
     
     Step by step guide on setting your basal rates
-    
--   __![Trio Logo](../../../assets/images/trio-logo.png){ width="20" }[Insulin Sensitivities](isf.md)__
-
-    - - -
-    
-    Step by step guide on setting your insulin sensitivity factor(s)
     
 -   __![Trio Logo](../../../assets/images/trio-logo.png){ width="20" }[Carb Ratios](carb-ratios.md)__
 
@@ -34,10 +34,10 @@ Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome
     
     Step by step guide on setting your carb ratio(s)
     
--   __[Glucose Targets](glucose-targets.md)__
+-   __![Trio Logo](../../../assets/images/trio-logo.png){ width="20" }[Insulin Sensitivities](isf.md)__
 
     - - -
     
-    Step by step guide on setting your glucose target(s)
+    Step by step guide on setting your insulin sensitivity factor(s)
     
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -271,10 +271,10 @@ nav:
           - Therapy:
               - configuration/settings/therapy/index.md
               - Units and Limits: configuration/settings/therapy/units-limits.md
-              - Basal Rates: configuration/settings/therapy/basal-rates.md
-              - Insulin Sensitivities: configuration/settings/therapy/isf.md
-              - Carb Ratios: configuration/settings/therapy/carb-ratios.md
               - Glucose Targets: configuration/settings/therapy/glucose-targets.md
+              - Basal Rates: configuration/settings/therapy/basal-rates.md
+              - Carb Ratios: configuration/settings/therapy/carb-ratios.md
+              - Insulin Sensitivities: configuration/settings/therapy/isf.md
           - Algorithm:
               - configuration/settings/algorithm/index.md
               - Autosens: configuration/settings/algorithm/autosens.md


### PR DESCRIPTION
This PR reorders the `Configuration > Trio Settings > Therapy` items in the Table of Contents (TOC) and index page.  
The table below describes the changes.

Before                           | After
---                              | ---
| 1. Units and Limits            | 1. Units and Limits          |
| 2. **Basal Rates**             | 2. **Glucose Targets**       |
| 3. **Insulin Sensitivities**   | 3. **Basal Rates**           |
| 4. **Carb Ratios**             | 4. **Carb Ratios**           |
| 5. **Glucose Targets**         | 5. **Insulin Sensitivities** |


> **Suggestion (not a blocker)**
> 
> The order of therapy settings in the app is now:
> 
> * units and limits
> * target glucose
> * basal rates
> * carb ratios
> * insulin sensitivites
> 
> perhaps reorder mkdocs.md and `configuration/settings/therapy/therapy.md` to match.

Source: [Marion's suggestion in the original Issue](https://github.com/ebouchut/Trio-dev-docs/issues/47#issuecomment-2833576932)


