### PR TITLE
♻️ Add a `Build` section above `Build with Mac` and `Build with Browser`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -229,29 +229,30 @@ nav:
               - Mac ✏️: install/build/requirements/devices/mac.md # TODO
               - Compatibility Matrix ✏️: install/build/requirements/devices/compatibility-matrix.md # TODO
           - Apple Developer Account: install/build/requirements/apple-developer.md
-      - Build with Mac:
-          - Mac Build Overview: install/build/mac/overview.md
-          - Prepare your Computer: install/build/mac/computer.md
-          - Prepare your iPhone: install/build/mac/iphone.md
-          - Set Up Xcode: install/build/mac/xcode-setup.md
-          - Build Trio with Xcode: install/build/mac/build.md
-          - Build Errors: install/build/mac/build-errors.md
-          - Update Trio with Xcode: install/build/mac/update.md
-      - Build with Browser ✏️:
-          - Browser Build Overview ✏️: install/build/browser/browser-build-overview.md
-          - Create GitHub Account ✏️: install/build/browser/create-github-account.md
-          - Collect Secrets ✏️: install/build/browser/collect-secrets.md
-          - Fork and Prepare your Trio Repository✏️: install/build/browser/fork-prepare-repo.md
-          - GitHub Actions ✏️:
-              - Validate Secrets ✏️: install/build/browser/actions/validate-secrets.md
-              - Add Identifiers ✏️: install/build/browser/actions/add-identifiers.md
-              - Prepare App ✏️: install/build/browser/actions/prepare-app.md
-              - Generate Certificates ✏️: install/build/browser/actions/generate-certificates.md
-              - Build the App ✏️: install/build/browser/actions/build-app.md
-          - Install Trio from TestFlight ✏️: install/build/browser/install-from-testflight.md
-          - Browser Build Errors ✏️: install/build/browser/browser-build-errors.md
-          - Customizations ✏️: install/build/browser/browser-customizations.md
-          - Update with Browser ✏️: install/build/browser/update-with-browser.md
+      - Build:
+          - Build with Mac:
+              - Mac Build Overview: install/build/mac/overview.md
+              - Prepare your Computer: install/build/mac/computer.md
+              - Prepare your iPhone: install/build/mac/iphone.md
+              - Set Up Xcode: install/build/mac/xcode-setup.md
+              - Build Trio with Xcode: install/build/mac/build.md
+              - Build Errors: install/build/mac/build-errors.md
+              - Update Trio with Xcode: install/build/mac/update.md
+          - Build with Browser ✏️:
+              - Browser Build Overview ✏️: install/build/browser/browser-build-overview.md
+              - Create GitHub Account ✏️: install/build/browser/create-github-account.md
+              - Collect Secrets ✏️: install/build/browser/collect-secrets.md
+              - Fork and Prepare your Trio Repository✏️: install/build/browser/fork-prepare-repo.md
+              - GitHub Actions ✏️:
+                  - Validate Secrets ✏️: install/build/browser/actions/validate-secrets.md
+                  - Add Identifiers ✏️: install/build/browser/actions/add-identifiers.md
+                  - Prepare App ✏️: install/build/browser/actions/prepare-app.md
+                  - Generate Certificates ✏️: install/build/browser/actions/generate-certificates.md
+                  - Build the App ✏️: install/build/browser/actions/build-app.md
+              - Install Trio from TestFlight ✏️: install/build/browser/install-from-testflight.md
+              - Browser Build Errors ✏️: install/build/browser/browser-build-errors.md
+              - Customizations ✏️: install/build/browser/browser-customizations.md
+              - Update with Browser ✏️: install/build/browser/update-with-browser.md
       - Upgrade ✏️: install/upgrade.md
       - Companion Apps:
           - install/ecosystem/index.md


### PR DESCRIPTION
This PR adds a `Build` section above `Build with Mac` and `Build with Browser`.
The beneficial outcome will be that both the `Build with Mac` and `Build with Browser` sections will be collapsed.”


### Before

> ![CleanShot 2025-05-15 at 16 07 16@2x](https://github.com/user-attachments/assets/1b71507e-431e-4660-894d-b99421220861)

### After

> ![CleanShot 2025-05-15 at 16 08 25@2x](https://github.com/user-attachments/assets/eb6b3172-5508-4ae5-a08d-d56f30d4d75f)
