### PR TITLE
Fix broken video display in Bolus Calculator page

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -233,3 +233,13 @@
 .loopGreen {
     color: #6FCE96
 }
+
+/*
+ * Video
+ */
+.video-center {
+  text-align: center;
+}
+.video-center video {
+  max-width: 100%;
+}

--- a/docs/usage/features/bolus-calculator.md
+++ b/docs/usage/features/bolus-calculator.md
@@ -18,7 +18,8 @@ There are 4 main sections of the Bolus Calculator Interface
 
 ### Dynamic Glucose Forecast
 
-As you enter your carbs and insulin, this dynamic graph at the top of the bolus calculator will adjust the forecast lines or cone to account for your future data.
+As you enter your carbs and insulin, this dynamic graph at the top of the bolus calculator will adjust the forecast lines or cone to account for your future data.  
+Watch the video below to see this in action.
 
 <div class="video-center">
   <video controls  preload="metadata" height="664" width="334">

--- a/docs/usage/features/bolus-calculator.md
+++ b/docs/usage/features/bolus-calculator.md
@@ -20,10 +20,12 @@ There are 4 main sections of the Bolus Calculator Interface
 
 As you enter your carbs and insulin, this dynamic graph at the top of the bolus calculator will adjust the forecast lines or cone to account for your future data.
 
-<video controls  preload="metadata" height="664" width="334">
-  <source src="/usage/img/bolus-entry-dynamic-graph.mp4" type="video/mp4">
-  Your browser doesn’t support the HTML5 video tag.
-</video>
+<div class="video-center">
+  <video controls  preload="metadata" height="664" width="334">
+    <source src="/usage/img/bolus-entry-dynamic-graph.mp4" type="video/mp4">
+    Your browser doesn’t support the HTML5 video tag.
+  </video>
+</div>
 
 
 ### Meal Entry

--- a/docs/usage/features/bolus-calculator.md
+++ b/docs/usage/features/bolus-calculator.md
@@ -20,8 +20,11 @@ There are 4 main sections of the Bolus Calculator Interface
 
 As you enter your carbs and insulin, this dynamic graph at the top of the bolus calculator will adjust the forecast lines or cone to account for your future data.
 
-![Dynamic Bolus Entry](../img/bolus-entry-dynamic-graph.mp4){width="500"}
-{align="center"}
+<video controls  preload="metadata" height="664" width="334">
+  <source src="/usage/img/bolus-entry-dynamic-graph.mp4" type="video/mp4">
+  Your browser doesn’t support the HTML5 video tag.
+</video>
+
 
 ### Meal Entry
 


### PR DESCRIPTION
This PR:
- Fixes the [broken video display](https://github.com/nightscout/trio-docs/blob/77d1202d0910b51c8715a7d4a737a16861f95b46/docs/usage/features/bolus-calculator.md?plain=1#L23-L24) in the Bolus Calculator page.
- **Resize** the **video** to 2/3 of its original size.
- **Center** the **video**
- Adds the ability to **center any video** (commit 51801c42ba2ce9c075298f69616725259bc43fb9) simply by surrounding its HTML `video` tag with a `div` tag. The `div` should have the `video-center` class ([See](https://github.com/nightscout/trio-docs/blob/ae591ea04a08e085e8738a063ff082bf09fc9954/docs/usage/features/bolus-calculator.md?plain=1#L24)). 

Fixes #143