### PR TITLE
Implement slugified anchors for content tabs based on their names

### DIFF
--- a/docs/configuration/new-user-setup.md
+++ b/docs/configuration/new-user-setup.md
@@ -340,8 +340,13 @@ Trio requires Bluetooth to function as a (hybrid) closed-loop system. If you do 
 <p style="text-align: center; font-size: 32px;">Congratulations!</p>
 <p style="text-align: center; font-size: 24px;">But, you're not done yet!</p>  
 
-![Home Screen Mockup](img/trio-phone-mockup.mp4){ width="500px" }
-{ align=center }
+<div class="video-center" label="Home Screen Mockup">
+  <video controls  preload="metadata" width="500" height="500">
+    <source src="/configuration/img/trio-phone-mockup.mp4" type="video/mp4">
+      Your browser doesn’t support the HTML5 video tag.
+       <p>The video cannot be displayed. You can <a href="https://triodocs.org/usage/img/trio-phone-mockup.mp4">download it here</a>.</p>
+  </video>
+<</div>
 
 **Steps 7 & 8 are not in the Onboarding Wizard**  
 These cannot be completed until you've finished onboarding, but _must_ be completed before you can start using Trio.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ plugins:
       excluded_files:
         - back.html.j2
         - background.png
+        - bolus-entry-dynamic-graph.mp4
         - CNAME
         - .DS_Store
         - extra.css
@@ -115,6 +116,7 @@ plugins:
         - primary_color.css
         - trio-docs.pdf
         - trio-intro.mp4
+        - trio-phone-mockup.mp4
   - search
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,6 +178,10 @@ markdown_extensions:
         - includes/glossary.txt
   - pymdownx.tabbed:
       alternate_style: true
+      combine_header_slug: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - tables
   - toc:
       permalink: true


### PR DESCRIPTION
This PR:
- Improves the anchors for [Content Tabs](https://squidfunk.github.io/mkdocs-material/reference/content-tabs/?h=content+tabs#content-tabs).  
  See: Issue #138 for details.
- Fixes a broken video display at the bottom of the New User Guide (below Congratulations)
- Declare the video files as unused (because the `mkdocs-unused` does not detect files in HTML tags.
- Fixes #138.

### Content Tab Anchor

The anchor of a Content Tab is now constructed by concatenating the slugified version of the section name with the slugified version of the Content Tab.

> ℹ️ The **slugification**” is the process of converting a title or text into a URL-friendly “slug” by removing special characters, replacing spaces with hyphens, and converting it to lowercase.


### Example

In the example below:

- The **section name** is `Onboarding Wizard`.
- The second **Content Tab** is named `After Onboarding`.

This PR changes how the anchor for the second Content Tab is build.
It is no longer the Gibberish `#__tabbed_1_2` but `#onboarding-wizard-after-onboarding`

Here is how the anchor is now built:  
  `#slugify(SECTION_NAME)-slugify(CONTENT_TAB_NAME)`  

```markdown
## Onboarding Wizard

<div class="grid" markdown>

![Onboarding Screen](img/onboarding-guide.png)

=== "During Onboarding"
    
    Information under the **During Onboarding** tab provides additional information for that step of the Onboarding Wizard.  
    
    Use this documentation as your home base to refer back to as needed.
    
=== "After Onboarding"
    
    Information under the **After Onboarding** tab shows you where to edit the relevant settings after onboarding is complete as well as the additional information on those settings.  
    
    Use this documentation as your home base to refer back to as needed.
    
</div>
```

