### PR TITLE
❇️ 💄 Add a Lightbox (zoom)  effect to images

### DIFF
--- a/docs/0.2.x/index.md
+++ b/docs/0.2.x/index.md
@@ -4,7 +4,7 @@
 
 # What is Trio?
 
-![Trio Logo](assets/images/trio-logo.png){ width="150", align="right" }
+![Trio Logo](assets/images/trio-logo.png){ .skip-lightbox width="150" align="right" }
 
 Trio is an automated insulin delivery system for iOS based on the [OpenAPS algorithm](https://github.com/OpenAPS/oref0) with [adaptations for Trio](https://github.com/nightscout/trio-oref).
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,6 +1,6 @@
 # Configuration
 
-![Trio Logo](../assets/images/trio-logo.png){ width="75", align="left"}
+![Trio Logo](../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" }
 Welcome to the Configuration homepage! Here you will find all the information needed to setup your app after you've built it. Configuration involves adjusting your settings. It is important that you do this in an educated way, so this section is here to guide you!  
 
 Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome-solid-magnifying-glass:, or the menu below to find the section you are looking for.

--- a/docs/configuration/migration/index.md
+++ b/docs/configuration/migration/index.md
@@ -1,6 +1,6 @@
 # Migration from other OS-AIDs
 
-![Trio Logo](../../assets/images/trio-logo.png){ width="75", align="left"}
+![Trio Logo](../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" }
 Welcome to the Migration homepage! Here you will find guidance on locating and identifying the necessary settings needed to start using Trio. Select the app you are moving from in the list below.
 
 Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome-solid-magnifying-glass:, or the menu below to find the section you are looking for.

--- a/docs/configuration/settings/algorithm/index.md
+++ b/docs/configuration/settings/algorithm/index.md
@@ -1,6 +1,6 @@
 # Algorithm
 
-![Trio Logo](../../../assets/images/trio-logo.png){ width="75", align="left"} Welcome to the Algorithm Settings homepage! Here you'll find information on the settings that influence the algorithm that runs Trio.
+![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" } Welcome to the Algorithm Settings homepage! Here you'll find information on the settings that influence the algorithm that runs Trio.
 
 - - -
 

--- a/docs/configuration/settings/devices/index.md
+++ b/docs/configuration/settings/devices/index.md
@@ -1,6 +1,6 @@
 # Devices
 
-![Trio Logo](../../../assets/images/trio-logo.png){ width="75", align="left"} Welcome to the Devices homepage! Here you'll find information on which devices are compatible with Trio and how to add your compatible devices to your Trio app.
+![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox  width="75" align="left" } Welcome to the Devices homepage! Here you'll find information on which devices are compatible with Trio and how to add your compatible devices to your Trio app.
 
 - - -
 

--- a/docs/configuration/settings/features/index.md
+++ b/docs/configuration/settings/features/index.md
@@ -1,6 +1,6 @@
 # Features
 
-![Trio Logo](../../../assets/images/trio-logo.png){ width="75", align="left"} Welcome to the features homepage! Here you'll find information on a variety of customization features available to you in the Trio app.  
+![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" } Welcome to the features homepage! Here you'll find information on a variety of customization features available to you in the Trio app.  
 
 - - -
 

--- a/docs/configuration/settings/index.md
+++ b/docs/configuration/settings/index.md
@@ -1,6 +1,6 @@
 # Trio Settings
 
-![Trio Logo](../../assets/images/trio-logo.png){ width="75", align="left"}
+![Trio Logo](../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" }
 Welcome to the Trio Settings homepage! Here you'll find explanations of all the settings in Trio. They are organized by their appearance in the Settings Menu in the Trio app.  
 
 - - -

--- a/docs/configuration/settings/notifications/index.md
+++ b/docs/configuration/settings/notifications/index.md
@@ -1,6 +1,6 @@
 # Notifications
 
-![Trio Logo](../../../assets/images/trio-logo.png){ width="75", align="left"} Welcome to the Notifications homepage! Here you'll find information on the various methods of keeping you updated on Trio's status and important information while you are not actively using the app.
+![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" } Welcome to the Notifications homepage! Here you'll find information on the various methods of keeping you updated on Trio's status and important information while you are not actively using the app.
 
 - - -  
 

--- a/docs/configuration/settings/services/index.md
+++ b/docs/configuration/settings/services/index.md
@@ -1,6 +1,6 @@
 # Services
 
-![Trio Logo](../../../assets/images/trio-logo.png){ width="75", align="left"} Welcome to the Services homepage! This section provides you with additional information on the services built into the Trio app. There are also [Companion Apps](../../../install/ecosystem/index.md) that will work alongside Trio.  
+![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" } Welcome to the Services homepage! This section provides you with additional information on the services built into the Trio app. There are also [Companion Apps](../../../install/ecosystem/index.md) that will work alongside Trio.  
 
 Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome-solid-magnifying-glass:, or the menu below to find the section you are looking for.
 

--- a/docs/configuration/settings/therapy/index.md
+++ b/docs/configuration/settings/therapy/index.md
@@ -1,6 +1,6 @@
 # Therapy
 
-![Trio Logo](../../../assets/images/trio-logo.png){ width="75", align="left"} 
+![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" }
 
 Welcome to the Therapy Settings homepage! Here you will find the "Trio" of core settings, your basal rates, ISF, and CR. You'll also find the units and targets essential for a functioning Trio closed loop.
 
@@ -22,19 +22,19 @@ Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome
     
     Step by step guide on setting your glucose target(s)
     
--   __![Trio Logo](../../../assets/images/trio-logo.png){ width="20" }[Basal Rates](basal-rates.md)__
+-   __![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox  width="20" }[Basal Rates](basal-rates.md)__
 
     - - -
     
     Step by step guide on setting your basal rates
     
--   __![Trio Logo](../../../assets/images/trio-logo.png){ width="20" }[Carb Ratios](carb-ratios.md)__
+-   __![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox  width="20" }[Carb Ratios](carb-ratios.md)__
 
     - - -
     
     Step by step guide on setting your carb ratio(s)
     
--   __![Trio Logo](../../../assets/images/trio-logo.png){ width="20" }[Insulin Sensitivities](isf.md)__
+-   __![Trio Logo](../../../assets/images/trio-logo.png){ .skip-lightbox  width="20" }[Insulin Sensitivities](isf.md)__
 
     - - -
     

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -1,6 +1,6 @@
 # Help
 
-![Trio Logo](../assets/images/trio-logo.png){ width="75", align="left"}
+![Trio Logo](../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" }
 Welcome to the help homepage! Here you will find a variety of resources that will help in your use of Trio.  
 
 Please use the navigation menu :fontawesome-solid-bars:, search bar :fontawesome-solid-magnifying-glass:, or the menu below to find the section you are looking for.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
   Your browser doesn’t support the HTML5 video tag.
 </video>
 
-![Trio Logo](assets/images/trio-logo.png){ width="150", align="right" }
+![Trio Logo](assets/images/trio-logo.png){ .skip-lightbox width="150" align="right" }
 
 Trio is an open-source automated insulin delivery system (OS-AID) for iOS based on the [OpenAPS algorithm](https://github.com/OpenAPS/oref0) with [adaptations for Trio](https://github.com/nightscout/trio-oref).  
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,4 +49,4 @@ If you find yourself stuck, the community is here to help on [Discord](https://d
 
 Trio is built by a volunteer community. If you are interested in helping as a programmer, you can contribute to the [Trio](https://github.com/nightscout/Trio) or [Trio-Oref](https://github.com/nightscout/trio-oref) code base. Trio is written in Swift, and the Trio-Oref/OpenAPS algorithm is currently written in JS and is in the process of being converted into Swift.
 
-You can also provide support in online support groups by sharing your own success and troubleshoot common errors.
+You can also provide support in online support groups by sharing your own success and troubleshooting common errors.

--- a/docs/install/ecosystem/index.md
+++ b/docs/install/ecosystem/index.md
@@ -1,6 +1,6 @@
 # Companion Apps
 
-![Trio Logo](../../assets/images/trio-logo.png){ width="75", align="left"} Welcome to the Companion Applications homepage! These apps all work within the Trio ecosystem. They are separate apps that are interoperable with Trio and many other DIY AID systems.  
+![Trio Logo](../../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" } Welcome to the Companion Applications homepage! These apps all work within the Trio ecosystem. They are separate apps that are interoperable with Trio and many other DIY AID systems.  
 
 - - -
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,6 +1,6 @@
 # Installation and Update
 
-![Trio Logo](../assets/images/trio-logo.png){ width="75", align="left"}
+![Trio Logo](../assets/images/trio-logo.png){  .skip-lightbox width="75" align="left" }
 
 Welcome to the installation and update homepage! Here you will find information about building, installing, and updating your Trio app.
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,6 +1,6 @@
 # Usage
 
-![Trio Logo](../assets/images/trio-logo.png){ width="75", align="left"}
+![Trio Logo](../assets/images/trio-logo.png){ .skip-lightbox width="75" align="left" }
 
 Welcome to the Usage homepage! Here you will find a variety of topics to learn about that will help you in using Trio to manage your diabetes.  
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,10 @@ plugins:
           icon: material-file-download-outline
           enabled: !!python/name:mkdocs_exporter.formats.pdf.buttons.download.enabled
           attributes: !!python/name:mkdocs_exporter.formats.pdf.buttons.download.attributes
+  - glightbox:
+      zoomable: false
+      skip_classes:
+        - skip-lightbox
   - htmlproofer:
       enabled: !ENV [CHECK_BROKEN_LINKS, False]
       raise_error_after_finish: true

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ jinja2~=3.1
 mkdocs~=1.6.1
 mkdocs-exporter~=6.2
 mkdocs-material~=9.6
+mkdocs-glightbox~=0.4
 mkdocs-htmlproofer-plugin~=1.3
 mkdocs-include-markdown-plugin~=7.1.5
 mkdocs-open-in-new-tab~=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,6 +77,8 @@ mkdocs-exporter==6.2.0
     # via -r requirements.in
 mkdocs-get-deps==0.2.0
     # via mkdocs
+mkdocs-glightbox==0.4.0
+    # via -r requirements.in
 mkdocs-htmlproofer-plugin==1.3.0
     # via -r requirements.in
 mkdocs-include-markdown-plugin==7.1.5


### PR DESCRIPTION
This PR:

- ✚ Adds the [`mkdocs-glightbox`](https://github.com/blueswen/mkdocs-glightbox) dependency/plugin, which adds a **lightbox effect (zoom on click) to all images**.
- ❇️ Disable the lightbox effect on the Trio logos.
- Fixes issue #159.


Details on how to use it can be found in #159.