### PR TITLE
Remove Dynamic CR and improve Dynamic Settings page

### DIFF
--- a/docs/configuration/settings/algorithm/autosens.md
+++ b/docs/configuration/settings/algorithm/autosens.md
@@ -7,7 +7,7 @@
     - Autosens Max/Min limits sensitivity adjustments
 
 ## Sensitivity Ratio
-The Sensitivity Ratio (previously `Autosens Ratio`) is used to calculate the amount of adjustment needed to your basal rates and ISF. If Dynamic CR is enabled, it will also apply to your carb ratio.  
+The Sensitivity Ratio (previously `Autosens Ratio`) is used to calculate the amount of adjustment needed to your basal rates and ISF.
 
 !!! tip
     This previously was shown as a decimal value as `Autosens Ratio` and is now shown as a percentage as `Sensitivity Ratio`.
@@ -19,8 +19,8 @@ The Sensitivity Ratio (previously `Autosens Ratio`) is used to calculate the amo
 There are 3 options for you to select from for how your Sensitivity Ratio is calculated:
     
 - [Autosens](#autosens): Adjusts your Sensitivity Ratio based on a series of comparisons of the last 8 hours versus the last 24 hours of insulin usage. **This is the default calculation.**
-- [Logarithmic Dynamic ISF](./dynamic-settings.md#activate-dynamic-isf): Adjusts your Sensitivity Ratio based on your Total Daily Dose (TDD) from the last 24 hours vs the last 10 days to adjust your Sensitivity Ratio.
-- [Sigmoid Dynamic ISF](): Adjusts your Sensitivity Ratio based on how far above or below target your current glucose reading is.
+- [Logarithmic Dynamic ISF](./dynamic-settings.md#dynamic-isf-logarithmic): Adjusts your Sensitivity Ratio based on your Total Daily Dose (TDD) from the last 24 hours vs the last 10 days to adjust your Sensitivity Ratio.
+- [Sigmoid Dynamic ISF](./dynamic-settings.md#dynamic-isf-sigmoid): Adjusts your Sensitivity Ratio based on how far above or below target your current glucose reading is.
 
 !!! note
     All 3 options are limited by your [Autosens Max](#autosens-max) and [Autosens Min](#autosens-min) settings. These settings prevent over-adjusting.

--- a/docs/configuration/settings/algorithm/dynamic-settings.md
+++ b/docs/configuration/settings/algorithm/dynamic-settings.md
@@ -1,27 +1,33 @@
 # Dynamic Settings
 
-## Activate Dynamic ISF
-**Default:** _OFF_
+## Dynamic ISF: Logarithmic
+**Default:** _Disabled_
 
 !!! danger "Important"
     It is important to enter your information into the Desmos graphs found [here](#logarithmic-desmos-graphs) **before** turning on Logarithmic Dynamic ISF. The default settings work for a majority of users, but not all.  
     
-    Use the sliders in Desmos to determine what your Adjustment Factor (AF) should be so that your ProfileISF is used when your glucose is at **_150 mg/dL_**.  
+    Use the sliders in Desmos to determine what your Adjustment Factor (AF) should be so that your ProfileISF is used when your glucose is at **_150 mg/dL (8.3 mmol/L)_**.  
 
 
 !!! tip
-    You must first turn on `Activate Dynamic ISF` before any other dynamic features will appear
+    You must first choose `Logarithmic` or `Sigmoid` before any other dynamic features will appear
 
-Activating this feature allows Trio to calculate your [Sensitivity Ratio](./autosens.md#sensitivity-ratio) using the logarithmic dynamic formula, rather than the [Autosens formula](./autosens.md#autosens) with each loop cycle by considering factors such as: your current glucose (BG), the weighted total daily dose of insulin (TDD), your adjustment factor setting (AF), and a few other data points. Using Logarithmic Dynamic ISF allows you to customize your Sensitivity Ratio calculation beyond what is allowed with Autosens.  
+Activating this feature allows Trio to calculate your [Sensitivity Ratio](./autosens.md#sensitivity-ratio) using the logarithmic dynamic formula, rather than the [Autosens formula](./autosens.md#autosens) with each loop cycle by considering factors such as: your current glucose, the weighted total daily dose of insulin (TDD), your adjustment factor setting (AF), and a few other data points. Using Logarithmic Dynamic ISF allows you to customize your Sensitivity Ratio calculation beyond what is allowed with Autosens.  
 
-Below is the formula used for calculating the Sensitivity Ratio using Logarithmic Dynamic ISF:
+Below is the formula used for calculating the Sensitivity Ratio using Logarithmic Dynamic ISF for mg/dL:
 
 $$
-Sensitivity\ Ratio = ProfileISF \times AF \times TDD \times \log{}\left(\frac{\left(\frac{BG}{peak}\right)+1}{1800}\right)
+Sensitivity\ Ratio = ProfileISF \times AF \times TDD \times \ln{}\left(\frac{\left(\frac{Glucose}{Peak}\right)+1}{1800}\right)
+$$
+
+Here is that same formula adjusted for mmol/L:
+
+$$
+Sensitivity\ Ratio = ProfileISF \times AF \times TDD \times \ln{}\left(\frac{\left(\frac{Glucose}{0.0555 \times Peak}\right)+1}{1800}\right)
 $$
 
 !!! info
-    This formula considers your Profile ISF (ProfileISF in mg/dL), current blood glucose (BG in mg/dL), total daily dose (TDD over the last 24 hours), insulin peak effect (Peak), and Adjustment Factor (AF) that allows for user tuning of Dynamic ISF/CR.
+    This formula considers your profile ISF, current glucose, total daily dose (TDD over the last 24 hours), insulin peak effect (Peak), and Adjustment Factor (AF) that allows for user tuning of Dynamic ISF.
 
 After the Sensitivity Ratio is calculated, your Calculated Sensitivity is then determined by using the same formula as [Autosens](./autosens.md#calculated-sensitivity):
 
@@ -32,31 +38,10 @@ $$
 
 - - -
 
-## Activate Dynamic CR
-**Default:** _OFF_
+## Dynamic ISF: Sigmoid
+**Default:** _Disabled_
 
-This experimental feature alters the carb ratio (CR) based on current blood sugar and total daily dose (TDD). Unlike ISF, CR was not originally altered by autosens with respect to your detected sensitivity. Using Dynamic CR will lead to a dramatic change in how CR is calculated by Trio. Dynamic CR uses the same [formula](#activate-dynamic-isf) as logarithmic Dynamic ISF to calculate Sensitivity Ratio. It then uses that to adjust your Carb Ratio (CR) using this formula:
-
-$$
-NewCR = \frac{ProfileCR}{Sensitivity\ Ratio}
-$$
-
-When your Sensitivity Ratio increases, indicating you need more insulin, the carb ratio value is decreased to make your insulin dosing more effective. Conversely, when your Sensitivity Ratio decreases, the carb ratio is increased to avoid over-delivery.
-
-!!! note
-    
-    If the calculated Sensitivity Ratio used by Dynamic CR is greater than 1, the following formula is used to make the resulting CR less aggressive: 
-    
-    $$
-    Sensitivity\ Ratio = \left(\frac{Sensitivity\ Ratio - 1}{2}\right) + 1
-    $$
-
-- - -
-
-## Use Sigmoid Formula
-**Default:** _OFF_
-
-Turning on the Sigmoid Formula setting replaces the default logarithmic formula used to determine your Sensitivity Ratio. Your Calculated Sensitivity and Dynamic CR (if enabled) are calculated using a sigmoid curve rather than the default logarithmic function.
+Turning on the Sigmoid Formula setting replaces the default logarithmic formula used to determine your Sensitivity Ratio. Your Calculated Sensitivity is calculated using a sigmoid curve rather than the logarithmic function.
 
 The curve's steepness, reflecting how big adjustments are from one reading to another, is influenced by the [Adjustment Factor](#sigmoid-adjustment-factor), while [Autosens Max](./autosens.md#autosens-max) and [Min](./autosens.md#autosens-min) settings determine the limits of the ratio adjustment. Autosens Max and Min can also influence the curve's steepness with the Sigmoid Formula.
 
@@ -87,7 +72,7 @@ Adjusting this value shifts and steepens the curve of logarithmic Dynamic ISF. I
     
     ***Adjustment Factor (AF) is not a safety limiter***
     
-     - Increasing AF means you are telling the system that ALL dynamically calculated ISF/CR values have not been aggressive enough, and you want the system to make them more aggressive.
+     - Increasing AF means you are telling the system that ALL dynamically calculated ISF values have not been aggressive enough, and you want the system to make them more aggressive.
      - Decreasing AF means you are telling the system that ALL dynamically calculated values are too aggressive, and to make them less so.
 
 - - -

--- a/docs/configuration/settings/algorithm/dynamic-settings.md
+++ b/docs/configuration/settings/algorithm/dynamic-settings.md
@@ -23,7 +23,7 @@ $$
 Here is that same formula adjusted for mmol/L:
 
 $$
-Sensitivity\ Ratio = ProfileISF \times AF \times TDD \times \ln{}\left(\frac{\left(\frac{Glucose}{0.0555 \times Peak}\right)+1}{1800}\right)
+Sensitivity\ Ratio = ProfileISF \times AF \times TDD \times \ln{}\left(\frac{\left(\frac{Glucose}{0.0555 \times Peak}\right)+1}{100}\right)
 $$
 
 !!! info

--- a/docs/help/troubleshoot.md
+++ b/docs/help/troubleshoot.md
@@ -67,7 +67,6 @@ If your BG rises fast and ends up too high, it is usually because the carbs were
 Trio calculates the amount of insulin needed to bring blood glucose back into range. Additional insulin is needed when blood glucose remains high after a meal, but Trio needs the correct settings to make those adjustments. 
 
 - The first adjustment should be to reduce your CR. Reducing your carb ratio will result in **more** insulin for the carbs entered.
-- If you notice that your CR needs fluctuate based on your blood sugar level at the time, evaluate activating the [Dynamic CR](../configuration/settings/algorithm/dynamic-settings.md#activate-dynamic-cr) setting. 
 
 ### Fast Rise, Then Low
 
@@ -77,6 +76,6 @@ In this scenario, you are not getting enough insulin upfront to deal with the ca
 
 1. If all the delivered insulin is from one bolus, you should consider adjusting your CR setting so that the bolus calculator gives you less insulin. You could also consider pre-bolusing, giving the insulin some time to absorb before you start eating.
 2. If the delivered insulin is part bolus and part SMBs, you should consider adjusting your ISF setting so that the SMBs give you less insulin. It would help if you also considered pre-bolusing, giving the insulin more time to absorb before you start eating.
-3. In both (1) and (2), if you use dynamic ISF and CR features, you should consider lowering the Adjustment Factor and adjusting the Autosens max/min settings.
+3. In both (1) and (2), if you use the dynamic ISF feature, you should consider lowering the Adjustment Factor and adjusting the Autosens max/min settings.
 
 Please read through the chapters on [Autosens](../configuration/settings/algorithm/autosens.md) and [Dynamic settings](../configuration/settings/algorithm/dynamic-settings.md).


### PR DESCRIPTION
* Remove Dynamic CR, as it is no longer part of Trio
* Add mmol/L whenever mg/dL is used
* Clarify `ln()` instead of `log()`
  * In javascript, `log` really means `ln`
* Update language to match new language in Trio
* Drop "blood" from "blood glucose"

Screenshot of formula adjustments: 

<img width="666" alt="Screenshot 2025-05-24 at 11 05 34 PM" src="https://github.com/user-attachments/assets/e4ddd9e9-96f0-48c8-83fc-ebfcd45078d8" />
