### PR TITLE
🌐 Fix layout issues with site translation via Google Translate browser extension and on HSTS-preloaded domains

### DIFF
--- a/docs/assets/javascripts/disable-instant-if-translated.js
+++ b/docs/assets/javascripts/disable-instant-if-translated.js
@@ -1,0 +1,23 @@
+// Disable navigation.instant if Google Translate is active
+// (translate.goog or browser extension)
+(function () {
+  const isGoogleTranslateProxy =
+    window.location.hostname.includes("translate.goog");
+
+  // Google Translate browser extension detection:
+  // It injects `translated-ltr` or `translated-rtl` class on <html>
+  const htmlClassList = document.documentElement.classList;
+  const isGoogleTranslateExtension =
+    htmlClassList.contains("translated-ltr") ||
+    htmlClassList.contains("translated-rtl");
+
+  if (isGoogleTranslateProxy || isGoogleTranslateExtension) {
+    // Disable Material instant navigation
+    document.documentElement.removeAttribute("data-md-instant");
+
+    // Optional: log for debugging
+    console.log(
+      "Instant loading disabled because Google Translate is active (proxy or extension).",
+    );
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,8 +68,8 @@ theme:
 plugins:
   - redirects:
       redirect_maps:
-        'startup-guide.md': 'configuration/new-user-setup.md'
-        'startup-guide/index.md': 'configuration/new-user-setup.md'
+        "startup-guide.md": "configuration/new-user-setup.md"
+        "startup-guide/index.md": "configuration/new-user-setup.md"
   - open-in-new-tab
   - macros
   - exporter:
@@ -128,6 +128,7 @@ extra_css:
   - assets/stylesheets/extra.css
 
 extra_javascript:
+  - assets/javascripts/disable-instant-if-translated.js
   - assets/javascripts/mathjax.js
   - assets/javascripts/mkdocs-exporter.js
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js


### PR DESCRIPTION
This PR fixes #172 by disabling `navigation.instant` when the TrioDocs website is translated using `translate.goog` or the *Google Translate* extension.

## Issue Description

TrioDocs utilizes Mkdocs-material's [`instant loading`](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading) feature.
> When translating the TrioDocs website through Google Translate, the translated version showcases a layout issue.

[*Instant loading* is activated in TrioDocs](https://github.com/nightscout/trio-docs/blob/e668bd0684265b9f1d23b50ad33634a23c2cccab/mkdocs.yml#L55), which dynamically injects content that *Google Translate* does not process correctly.

```yaml
theme:
  features:
    - navigation.instant
```

Please, take a look at #172 for a snapshot.


## Test Instructions

This example assumes that `origin` is the name of the Git remote for your clone of `nightscout/trio-docs`. Adjust if necessary.

- **Activate GitHub Pages** (one-shot) for your clone of `nightscout/trio-docs`.  
  Follow the instructions below the image.  
  > ![CleanShot 2025-06-12 at 08 17 55@2x](https://github.com/user-attachments/assets/77781ecb-d98e-47e6-b4fc-3356ff54c0c0)
    - Open **your** copy of the trio-docs repository on GitHub:  
      `https://github.com/YOUR_GITHUB_USERNAME_HERE/trio-docs`
    - Click the **`⚙️ Settings`** tab (last tab on the right)
    - Click **`Pages`** under the `Code and Automation` section
        - In the `Source` field, select `Deploy from a Branch`
        - In the Branch section:
            - First drop-down: Select `gh-pages`
            - Second drop-down: Select `/(root)`
            - Click `Save`
- **Deploy** your copy of TrioDocs
    - Change directory into your local clone repository of `nightscout/trio-docs`
      ```shell
      cd trio-docs
      venv/bin/activate # if your shell prompt does not contain (venv)
      mkdocs deploy -r origin
      ```
    - Open **your** TrioDocs URL  
      This is the URL where **your** repository of trio-docs has been deployed to. It is mentioned in the GitHub Action and should look like:  
      `https://YOUR_GITHUB_USERNAME_HERE.github.io/trio-docs`
- **Verify** the deployed site through Google Translate
    - Open [Google Translate](https://translate.google.com/?sl=en&tl=fr&op=translate)
        - Paste **your** Trio-Docs URL in the **left** textarea (source language)      
        - Click the link displayed in the **right** textarea (destination language)
    - Result
        - Actual: https://triodocs-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=fr&_x_tr_hl=en&_x_tr_pto=wapp
        - Expected: The layout should be correct with no 404.

## Cleanup

When you are done with testing, unpublish **your** TrioDocs website.

> ![CleanShot 2025-06-12 at 09 12 29@2x](https://github.com/user-attachments/assets/a81a237f-dc6c-40e5-8e7b-ab9b96366de4)
