### PR TITLE
Fix typo in Table of Identifiers

### DIFF
--- a/docs/install/build/browser/update-with-browser.md
+++ b/docs/install/build/browser/update-with-browser.md
@@ -261,7 +261,7 @@ These are the <code>Identifiers</code> created by running the *GitHub* action "<
 | Trio | XC org nightscout TEAMID trio | <code>org.nightscout.TEAMID.trio</code> |
 | Trio LiveActivity | - | <code>org.nightscout.TEAMID.trio.LiveActivity</code> |
 | Trio Watch | XC IDENTIFIER | <code>org.nightscout.TEAMID.trio.watchkitapp</code> |
-| Trio WatchKit Extension | XC IDENTIFIER | <code>org.nightscout.TEAMID.trio.watchkitapp.watchkitextension</code> |
+| Trio Watch Complication | XC IDENTIFIER | <code>org.nightscout.TEAMID.trio.watchkitapp.TrioWatchComplication</code> |
 
 ### Add Trio App Group to <code>Identifiers</code>
 

--- a/docs/install/build/browser/update-with-browser.md
+++ b/docs/install/build/browser/update-with-browser.md
@@ -260,7 +260,7 @@ These are the <code>Identifiers</code> created by running the *GitHub* action "<
 |:--|:--|:--|
 | Trio | XC org nightscout TEAMID trio | <code>org.nightscout.TEAMID.trio</code> |
 | Trio LiveActivity | - | <code>org.nightscout.TEAMID.trio.LiveActivity</code> |
-| Trio Watch | XC IDENTIFIER | <code>org.nightscout.TEAMID.trio.watchkitapp</code> |
+| Trio Watch App | XC IDENTIFIER | <code>org.nightscout.TEAMID.trio.watchkitapp</code> |
 | Trio Watch Complication | XC IDENTIFIER | <code>org.nightscout.TEAMID.trio.watchkitapp.TrioWatchComplication</code> |
 
 ### Add Trio App Group to <code>Identifiers</code>


### PR DESCRIPTION
The table of Identifiers was not updated properly for `dev` branch.
It was copied from 0.2.x version and I missed the fact that the Trio Watch Complication replaces the Trio WatchKit Extension.
This PR updates the table. 