### PR TITLE
🛠️ Set minimum required Python version to 3.9 and add `pyproject.toml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: ">=3.9"
 
       - name: Create, Activate and share a Python Virtual Env
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: ">=3.9"
 
       - name: Create, Activate and share a Python Virtual Env
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,14 @@
 [project]
+name = "trio-docs"
+version = "0.1.0"
 requires-python = ">=3.9"
+description = "Documentation of Trio, an Automated Insulin Delivery system for iOS"
+readme = "README.md"
+license = {text = "AGPL-3.0-only"}
+license-files = ["LICENSE"]
+
+[project.urls]
+Homepage = "https://triodocs.org/"
+Documentation = "https://triodocs.org/"
+Repository = "https://github.com/nightscout/trio-docs.git"
+Issues = "https://github.com/nightscout/trio-docs/issues"


### PR DESCRIPTION
This PR sets the minimum required Python version to **3.9**  in the **`pyproject.toml`** file. 
This version number is based on the project's dependencies

This configuration file can declare:
- The **dependencies** of a Python project (optional)
- The **build tools** (optional)
- The project **metadata** (project name, description, version, license, **minimum** required **Python version**)

I want to explore and get ready for a future migration from `requirements.txt` to `pyproject.toml`. 

Later on, I plan to test [**`uv`**](https://docs.astral.sh/uv/) instead of `pip` + `pip-tools` (build dependencies file `requirements.txt` includes direct and indirect dependencies from `requirements.in` which contains direct dependencies) + `venv` (to create or activate a Python **virtual environment** for a project to work in a "silo" without overwriting global Python dependencies (which may lead to difficult situations)).

One of the key features of `uv` is that it is **way** faster than `pip`.

See: [Discord](https://discord.com/channels/1020905149037813862/1239982886065799228/1383166904231006298) 