### PR TITLE
Set Python version in GitHub Actions workflow to 3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ">=3.9"
+          python-version: "3.12"
 
       - name: Create, Activate and share a Python Virtual Env
         run: |


### PR DESCRIPTION
To address publishing action error: https://github.com/nightscout/trio-docs/actions/runs/19800618727