### PR TITLE
Support Github codespaces for doc editing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Trio Docs Dev",
-    "image": "mcr.microsoft.com/devcontainers/python:3",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
     
     "waitFor": "postCreateCommand",
     "postCreateCommand": "python3 -m venv venv && ./venv/bin/pip install -r requirements.txt && ./venv/bin/pip install -r dev-requirements.txt",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+    "name": "Trio Docs",
+    "image": "mcr.microsoft.com/devcontainers/python:3",
+    "features": {
+      "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "postCreateCommand": "pip install -r requirements.txt && pip install -r dev-requirements.txt",
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "python.defaultInterpreterPath": "/usr/local/bin/python"
+        },
+        "extensions": [
+          "ms-python.python",
+          "yzhang.markdown-all-in-one" 
+        ]
+      }
+    },
+    "forwardPorts": [8000],
+    "portsAttributes": {
+      "8000": {
+        "label": "MkDocs Preview",
+        "onAutoForward": "notify"
+      }
+    }
+  }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,17 @@
 {
-    "name": "Trio Docs",
+    "name": "Trio Docs Dev",
     "image": "mcr.microsoft.com/devcontainers/python:3",
-    "features": {
-      "ghcr.io/devcontainers/features/git:1": {}
-    },
-    "postCreateCommand": "pip install -r requirements.txt && pip install -r dev-requirements.txt",
+    
+    "waitFor": "postCreateCommand",
+    "postCreateCommand": "python3 -m venv venv && ./venv/bin/pip install -r requirements.txt && ./venv/bin/pip install -r dev-requirements.txt",
+    
     "customizations": {
       "vscode": {
         "settings": {
-          "python.defaultInterpreterPath": "/usr/local/bin/python"
+          "python.defaultInterpreterPath": "./venv/bin/python",
+          "python.terminal.activateEnvironment": true
         },
-        "extensions": [
-          "ms-python.python",
-          "yzhang.markdown-all-in-one" 
-        ]
+        "extensions": ["yzhang.markdown-all-in-one"]
       }
     },
     "forwardPorts": [8000],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Run MkDocs",
+        "type": "shell",
+        "command": "mkdocs serve",
+        "isBackground": true,
+        "presentation": {
+          "reveal": "always",
+          "panel": "dedicated"
+        },
+        "runOptions": {
+          "runOn": "folderOpen"
+        },
+        "problemMatcher": []
+      }
+    ]
+  }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,19 +1,14 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-      {
-        "label": "Run MkDocs",
-        "type": "shell",
-        "command": "mkdocs serve",
-        "isBackground": true,
-        "presentation": {
-          "reveal": "always",
-          "panel": "dedicated"
-        },
-        "runOptions": {
-          "runOn": "folderOpen"
-        },
-        "problemMatcher": []
-      }
-    ]
-  }
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run MkDocs",
+      "type": "shell",
+      "command": "./venv/bin/mkdocs serve",
+      "isBackground": true,
+      "runOptions": { "runOn": "folderOpen" },
+      "presentation": { "reveal": "always", "panel": "dedicated" },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds a config file for devcontainers and a mkdocs vscode background task, which allows you to run and dynamically edit the docs site using GitHub Codespaces. 

With these changes checked into the repo, in a fork of the trio-docs repo, you can:
1. hit Code > Codespaces > New on the forked repo:
<img width="416" height="172" alt="image" src="https://github.com/user-attachments/assets/56895a5e-a9db-4944-91e4-3d2a2f4db2e9" />

2. A vscode web editor with the repo checked out opens (after a minute or so of spinning up the devcontainer):
<img width="1375" height="866" alt="image" src="https://github.com/user-attachments/assets/0e94be48-885a-4dd5-9440-a373bb9d4cdb" />

3. A live mkdocs doc site which reflects your live changes spins up:
<img width="1427" height="114" alt="image" src="https://github.com/user-attachments/assets/2942b6d5-134b-4776-8c4f-e62092e03a98" />

<img width="1377" height="867" alt="image" src="https://github.com/user-attachments/assets/aafa5059-3e00-4399-b0cd-bcb442198624" />

 
This makes editing docs easier since you don't need to check out the repo. GitHub gives you 120 hours of codespace usage per user per month: https://docs.github.com/en/billing/concepts/product-billing/github-codespaces#free-quota