### PR TITLE
Replace deprecated datetime.utcnow() with timezone-aware alternative

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 def define_env(env):
     # Define a macro that returns the current build date in UTC
-    env.variables['build_date'] = datetime.utcnow().strftime('%B %d, %Y')
+    env.variables['build_date'] = datetime.now(timezone.utc).strftime('%B %d, %Y')


### PR DESCRIPTION
- Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` for the build date macro
- `datetime.utcnow()` is deprecated in Python 3.12+ and will be removed in a future version