### PR TITLE
Clarify Trio name and OS-AID in introduction

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,11 @@
 
 ![Trio Logo](assets/images/trio-logo.png){ .skip-lightbox width="150" align="right" }
 
-Trio is an open-source automated insulin delivery system (OS-AID) for iOS based on the [OpenAPS algorithm](https://github.com/OpenAPS/oref0) with [adaptations for Trio](https://github.com/nightscout/trio-oref).  
+Trio is an Open-Source Automated Insulin Delivery (OS-AID) system for iOS building upon the 3 main data points of diabetes management, hence the main screen of Trio:
+
+1. Basal adjustments
+2. Glucose Readings
+3. Active insulin & Carbs
 
 This system considers your user-entered settings, carbohydrates, and historical insulin use to automate insulin delivery to reduce the time spent managing your diabetes.
 


### PR DESCRIPTION
Great start of the docs! But no where the name is explained, which I find really confusing as a newcomer. Also the abbreviation OS-AID is not clearly written or explained for a newbe, because it starts after system which would have meant OS-AIDS. So here a new proposal introduction text to refine:

Trio is an Open-Source Automated Insulin Delivery (OS-AID) application for iOS building upon the 3 pillars of OS-AID, hence the name:
1. OpenAPS algorithm (https://github.com/OpenAPS/oref0 )
2. Loopkit (https://github.com/LoopKit )
3. FreeAPS X (https://github.com/ivalkou/freeaps )

OR is it:

Trio is an Open-Source Automated Insulin Delivery (OS-AID) system for iOS building upon the 3 drivers of OS-AID:
1. User-entered settings
2. Carbohydrates
3. Historical insulin use 

OR is it:

Trio is an Open-Source Automated Insulin Delivery (OS-AID) system for iOS building upon the 3 main data points of diabetes management, hence the main screen of Trio:
1. Basal adjustments
2. Glucose Readings
3. Active insulin & Carbs

Or is it all 3! as a 3^3 :)